### PR TITLE
🧹 Simplify Nested Sections in List Template

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,22 +15,18 @@
 {{ if gt (len $pages) 0 }}
 <section>
   <div class="container">
-    <section>
-      <section>
-        <div class="posts">
-          {{ range $pages }}
-          <div class="post">
-            <a href="{{ .RelPermalink }}">
-              <div class="post-row">
-                <time>{{ .Date.Format "Jan 02" }}</time>
-                <h3>{{ .Title }}</h3>
-              </div>
-            </a>
+    <div class="posts">
+      {{ range $pages }}
+      <div class="post">
+        <a href="{{ .RelPermalink }}">
+          <div class="post-row">
+            <time>{{ .Date.Format "Jan 02" }}</time>
+            <h3>{{ .Title }}</h3>
           </div>
-          {{ end }}
-        </div>
-      </section>
-    </section>
+        </a>
+      </div>
+      {{ end }}
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
Simplified the nested section structure in `layouts/_default/list.html` by removing redundant `<section>` tags. This flattens the DOM and improves code readability without changing the layout or functionality.

---
*PR created automatically by Jules for task [11424486258500383968](https://jules.google.com/task/11424486258500383968) started by @yoonsoo-park*