### PR TITLE
🧹 Refactor verbose author assignment logic in single.html

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,10 +7,7 @@
                     <h1>{{ .Title }}</h1>
                     <div class="post-meta">
                         <div>
-                            {{ $author := .Params.author }}
-                            {{ if eq $author nil }}
-                              {{ $author = .Site.Params.author }}
-                            {{ end }}
+                            {{ $author := .Params.author | default .Site.Params.author }}
                             By {{ $author  }} | <time>{{ .Date.Format "January 02, 2006" }}</time>
                             | {{ .ReadingTime }} minutes
                         </div>


### PR DESCRIPTION
The code health issue in `layouts/_default/single.html` involved a verbose template logic for assigning the author variable. I refactored this by using the Hugo `default` function, which is a standard and more concise way to handle fallback values in templates. 

🎯 **What:** Simplified author assignment logic.
💡 **Why:** Improved readability and maintainability of the template.
✅ **Verification:** Verified that the logic remains functionally equivalent while being more concise. Attempted a local build with `make build` (which failed as expected due to missing `hugo` binary in the environment, confirming no other local validation tools were available).
✨ **Result:** Cleaner template code.

---
*PR created automatically by Jules for task [11021537852938404755](https://jules.google.com/task/11021537852938404755) started by @yoonsoo-park*