### PR TITLE
blog: ElastiCache durability + RAG/agent patterns (en/ko)

### DIFF
--- a/content/blog/2026-06-03-elasticache-durability-rag-agent-patterns.en.md
+++ b/content/blog/2026-06-03-elasticache-durability-rag-agent-patterns.en.md
@@ -1,0 +1,112 @@
+---
+title: "ElastiCache Just Got Durable — What That Means for RAG and Agent Orchestration"
+date: 2026-06-03T12:00:00-04:00
+author: Yoonsoo Park
+description: "AWS added durability to ElastiCache for Valkey. Microsecond reads, no data loss. Here's where this actually changes the design — RAG semantic caches, Step Functions agent state, and DLQ retry buffers — for someone whose last serious cache work was Redis in n8n."
+categories:
+  - AWS
+  - AI
+tags:
+  - elasticache
+  - valkey
+  - redis
+  - rag
+  - agents
+  - step-functions
+  - caching
+---
+
+On June 2, 2026, AWS [announced durability for Amazon ElastiCache](https://aws.amazon.com/about-aws/whats-new/2026/06/durability-amazon-elasticache/) starting with Valkey 9.0. That sounds like a small line item, but it quietly changes what ElastiCache is *for*. Until last week, "cache" meant "fast but expendable." Now you can pick, per cluster, whether writes are durable across AZs, and ElastiCache becomes a legitimate primary store for things you used to dump into DynamoDB out of fear.
+
+This post is me thinking out loud about where that matters. I'm a backend/platform engineer whose last real cache project was Redis in n8n. Most of my recent work is AWS AI infra — RAG pipelines, agent orchestration with Step Functions, dead-letter retries. Cache patterns sit at the seam of all of those, and I want to make sure I'm not under-using them on the next project.
+
+## What actually changed
+
+Two new write modes, on top of the existing in-memory speed:
+
+| Mode | Write latency | Data loss window | Use when |
+|---|---|---|---|
+| Synchronous | single-digit ms | zero (persisted to ≥2 AZs before ack) | money, identity, state you cannot replay |
+| Asynchronous | microseconds (free) | up to 10s on AZ failure | hot path you can rebuild from a system of record |
+| (legacy) non-durable | microseconds | everything since last snapshot | true ephemeral cache |
+
+Reads stay at microseconds in all three. The transactional log lives across multiple AZs, so failover, restart, and recovery don't lose committed data.
+
+The headline phrase from the AWS blurb — "AI agent long-term memory, AI agent workflow state, knowledge bases for RAG applications" — is unusually direct. AWS is telling you what they expect people to build with this.
+
+## Pattern 1 — RAG semantic cache
+
+In a vanilla RAG path, every user query embeds → searches a vector store → re-ranks → calls the LLM. The vector search and the LLM call are the two expensive steps. Both are deterministic enough to cache.
+
+```
+User query
+  → embed (cheap)
+    → semantic cache lookup by embedding similarity     ← ElastiCache
+       hit  → return cached answer (microseconds)
+       miss → vector store + LLM call
+              → write {embedding hash : answer} back   ← ElastiCache
+```
+
+Key shape options:
+
+- **Exact key**: hash of the normalized prompt. Trivial to implement, low hit rate.
+- **Semantic key**: store the embedding and approximate-match on cosine similarity above some threshold. Higher hit rate but you need a vector index *inside* the cache. Valkey/Redis modules support this; you can also keep a small HNSW in memory.
+
+Why durability matters here: if your cache is ephemeral, every cluster restart cold-starts your LLM bill. Async durability is plenty — losing 10 seconds of cached answers is not a correctness problem, just a brief cost spike. Sync durability is overkill. **Default async, and remember you no longer have to choose between "cache" and "real store."**
+
+Pitfall I'd worry about: cache poisoning when the upstream RAG pipeline returns a hallucinated or stale answer once. That answer can sit in cache for the TTL and serve to other users. Always include a content-version key (model name + prompt template version + index version) so a deploy invalidates without manual flush.
+
+## Pattern 2 — Agent workflow state in Step Functions
+
+Step Functions gives you `Map`, `Parallel`, `Wait`, retry policies, and `.waitForTaskToken` for human-in-the-loop. What it doesn't give you cheaply is:
+
+- Mid-execution scratchpad bigger than the 256 KB state payload
+- Cross-execution memory ("this agent already saw this customer last hour")
+- Fast lookups that aren't worth a DynamoDB round trip
+
+Pre-durability ElastiCache solved the speed problem but felt risky for anything you couldn't reconstruct. With durable Valkey, the pattern becomes clean:
+
+- **Execution scoped state** (lives for one Step Functions run): key `agent:exec:<exec-arn>:<slot>`, TTL = max execution duration + buffer. Use sync writes if losing the slot would corrupt downstream steps; async otherwise.
+- **Agent long-term memory** (lives across runs): key `agent:user:<user-id>:facts`, no TTL or a long one. Sync writes — this is the memory the user expects to persist.
+- **Tool-call cache** (idempotency for expensive tools): key `tool:<tool-name>:<arg-hash>`, short TTL. Async is fine.
+
+Step Functions Lambda tasks read/write this directly. You no longer need a "memory service" Lambda in front. ElastiCache is the memory service.
+
+## Pattern 3 — DLQ retry coordinator
+
+This is the one I keep underbuilding. SQS dead-letter queues are great at catching failures, but the recovery story is usually a Lambda that drains the DLQ and reprocesses blindly. That works until you have *correlated* failures — same downstream API outage hits 1000 messages, you reprocess them all, they all fail again, you back off and retry, repeat.
+
+A cache-coordinated retry layer fixes this:
+
+```
+DLQ message arrives
+  → cache lookup: dlq:<failure-fingerprint>     ← ElastiCache
+     - count > N in window  → don't retry yet, set circuit-open flag
+     - count ≤ N            → increment, retry, on success delete key
+  → on circuit-open: skip retries until TTL expires
+```
+
+The fingerprint is whatever isolates the failure class — downstream service ID + error code, for example. The cache holds the rolling counter and the open-circuit flag. Sync durability matters here: if the counter resets on AZ failover, you lose your back-pressure and slam the recovering downstream the moment it comes back. This is a place where the new sync mode pays for itself.
+
+Bonus: the same cache can hold the per-key idempotency token so a retry that *did* partially succeed doesn't double-charge a payment or double-write a record.
+
+## Choosing between sync, async, and DynamoDB
+
+A rough heuristic I'm landing on:
+
+| Need | Pick |
+|---|---|
+| Rebuildable, hot path, cost matters | ElastiCache async |
+| Correctness-critical, low write rate, microsecond reads | ElastiCache sync |
+| Audit trail, queries beyond key lookup, infrequent access | DynamoDB |
+| Big blob, write-once-read-many | S3, with ElastiCache pointer |
+
+DynamoDB doesn't go away. It's still the right answer for anything you'll query by attribute, paginate, or audit. ElastiCache durability isn't a DynamoDB replacement — it's a way to stop using DynamoDB *as a poor cache*.
+
+## What I'm doing next
+
+- Adding a semantic-cache layer in front of the RAG step in our internal agent. Async writes, embedding-hash key, content-version included.
+- Replacing a small DynamoDB "agent scratchpad" table with a Valkey cluster for one workflow as a proof-of-concept. Sync writes for the slot the next state reads.
+- Sketching the DLQ coordinator pattern for our most retry-loud Step Function. This one I want to write a small spec for before building.
+
+If the last time you touched a cache was Redis in some workflow tool, this announcement is a reason to revisit. The "cache vs database" line just moved.

--- a/content/blog/2026-06-03-elasticache-durability-rag-agent-patterns.ko.md
+++ b/content/blog/2026-06-03-elasticache-durability-rag-agent-patterns.ko.md
@@ -1,0 +1,112 @@
+---
+title: "ElastiCache가 durable해졌다 — RAG와 에이전트 오케스트레이션 관점에서"
+date: 2026-06-03T12:00:00-04:00
+author: Yoonsoo Park
+description: "AWS가 ElastiCache for Valkey에 durability를 추가했다. 마이크로초 read 그대로, 데이터 손실 없음. RAG 시맨틱 캐시, Step Functions 에이전트 state, DLQ retry 버퍼 — 마지막 캐시 작업이 n8n의 Redis였던 사람의 정리 노트."
+categories:
+  - AWS
+  - AI
+tags:
+  - elasticache
+  - valkey
+  - redis
+  - rag
+  - agents
+  - step-functions
+  - caching
+---
+
+2026년 6월 2일, AWS가 [Amazon ElastiCache durability를 발표했다](https://aws.amazon.com/about-aws/whats-new/2026/06/durability-amazon-elasticache/) (Valkey 9.0부터). 한 줄짜리 release note 같지만, ElastiCache가 무엇을 위한 서비스인지에 대한 정의를 조용히 바꾸는 변화다. 지난주까지 "캐시"는 "빠르지만 날아가도 되는 것"이었다. 이제는 cluster 단위로 write durability를 선택할 수 있고, 그 결과 그동안 무서워서 DynamoDB에 처박아두던 데이터를 ElastiCache에 정식으로 둘 수 있다.
+
+이 글은 그 변화가 어디에서 의미 있는지 정리하는 노트다. 나는 AWS AI 인프라가 메인이고 — RAG 파이프라인, Step Functions 기반 에이전트 오케스트레이션, dead-letter retry — 마지막으로 진지하게 캐시를 다룬 게 n8n의 Redis였다. 이 셋의 접점에 캐시 패턴이 있는데, 다음 프로젝트에서 under-use하지 않으려고 한 번 정리한다.
+
+## 무엇이 바뀌었나
+
+기존 in-memory 속도 위에, 두 가지 새로운 write 모드가 추가됐다:
+
+| 모드 | Write latency | 손실 가능 구간 | 언제 쓰나 |
+|---|---|---|---|
+| Synchronous | single-digit ms | 0 (≥2 AZ persist 후 ack) | 돈, identity, replay 불가능한 state |
+| Asynchronous | microseconds (추가 비용 없음) | AZ 장애 시 최대 10초 | system of record에서 재구성 가능한 hot path |
+| (기존) non-durable | microseconds | 마지막 snapshot 이후 전부 | 진짜 ephemeral 캐시 |
+
+Read는 세 모드 모두 microsecond 그대로. 트랜잭션 로그가 multi-AZ에 있어서 failover, restart, recovery 시 commit된 데이터는 안 사라진다.
+
+AWS 공식 문구에서 유스케이스를 — "AI agent long-term memory, AI agent workflow state, knowledge bases for RAG applications" — 이렇게 직접 명시한 게 흔치 않다. 이걸로 뭘 만들기를 기대하는지 대놓고 알려준 셈.
+
+## 패턴 1 — RAG 시맨틱 캐시
+
+기본 RAG 흐름은: 사용자 query → embed → vector store search → re-rank → LLM 호출. 비싼 step은 vector search와 LLM 호출 두 개. 둘 다 결정적인 부분이 있어서 캐시 가능.
+
+```
+User query
+  → embed (cheap)
+    → semantic cache lookup by embedding similarity     ← ElastiCache
+       hit  → cached answer 반환 (microseconds)
+       miss → vector store + LLM 호출
+              → {embedding hash : answer} write back    ← ElastiCache
+```
+
+Key 설계 선택지:
+
+- **Exact key**: 정규화된 prompt의 hash. 구현 간단, hit rate 낮음.
+- **Semantic key**: embedding 자체를 저장하고 cosine similarity threshold 위로 approximate-match. Hit rate는 높지만 캐시 안에 vector index가 필요. Valkey/Redis 모듈로 가능하고, 작은 HNSW를 in-memory로 두는 방법도 있음.
+
+여기서 durability가 왜 중요한지: 캐시가 ephemeral이면 cluster restart마다 LLM 비용이 cold start. Async durability면 충분 — cached answer 10초 손실은 correctness 문제 아니고 비용 spike만. Sync는 과함. **기본은 async, 그리고 더 이상 "캐시 vs 진짜 store"를 고를 필요가 없다는 점만 기억.**
+
+밟을 함정: 업스트림 RAG가 한 번 hallucination 답변을 내놓으면 TTL 동안 다른 사용자한테 그대로 서빙됨. content-version key (model name + prompt template version + index version)를 항상 끼워서 deploy 시 manual flush 없이 자동 invalidate 되게 해야 함.
+
+## 패턴 2 — Step Functions 에이전트 워크플로 state
+
+Step Functions는 `Map`, `Parallel`, `Wait`, retry policy, `.waitForTaskToken`까지 잘 준다. 근데 싸게 안 주는 것들:
+
+- 256 KB state payload보다 큰 mid-execution scratchpad
+- Cross-execution memory ("이 에이전트가 한 시간 전에 이 고객을 본 적 있다")
+- DynamoDB round trip 쓰기 아까운 fast lookup
+
+Durability 전 ElastiCache는 속도는 줬지만 재구성 불가능한 데이터 두기엔 무서웠다. Durable Valkey면 패턴이 깔끔해진다:
+
+- **Execution scope state** (Step Functions run 1회 동안 살아있음): key `agent:exec:<exec-arn>:<slot>`, TTL = max execution duration + buffer. Slot 손실이 downstream step을 망가뜨리면 sync write, 아니면 async.
+- **Agent long-term memory** (run 사이에 살아있음): key `agent:user:<user-id>:facts`, TTL 없음 또는 길게. Sync write — 사용자가 persist를 기대하는 메모리.
+- **Tool-call cache** (비싼 tool에 대한 idempotency): key `tool:<tool-name>:<arg-hash>`, 짧은 TTL. Async OK.
+
+Step Functions의 Lambda task가 직접 read/write. 앞에 "memory service" Lambda 따로 둘 필요 없다. ElastiCache가 memory service.
+
+## 패턴 3 — DLQ retry coordinator
+
+매번 under-build하는 영역. SQS dead-letter queue는 실패 잡는 데는 좋은데, 복구 로직이 보통 "Lambda가 DLQ를 drain해서 무지성 reprocess"로 끝난다. 그게 *상관관계 있는* 실패에서 깨진다 — 동일 downstream API 장애로 1000개가 한 번에 DLQ에 들어가면, 다 reprocess, 다 다시 실패, back-off하고 retry, 반복.
+
+Cache-coordinated retry layer가 이걸 푼다:
+
+```
+DLQ message 도착
+  → cache lookup: dlq:<failure-fingerprint>     ← ElastiCache
+     - window 내 count > N  → retry 보류, circuit-open flag set
+     - count ≤ N            → 증가, retry, 성공 시 key 삭제
+  → circuit-open이면: TTL 만료까지 retry skip
+```
+
+Fingerprint는 실패 class를 격리할 수 있는 무엇이든 — downstream service ID + error code 같은 식. Counter와 open-circuit flag를 캐시가 들고 있음. **여기는 sync durability가 진짜 값을 한다**: AZ failover로 counter가 리셋되면 back-pressure가 사라져서 막 살아난 downstream을 다시 때림. 새 sync 모드가 본전 뽑는 자리.
+
+보너스: 같은 캐시가 per-key idempotency token도 들고 있으면, *부분적으로 성공한* retry가 결제 중복이나 record 중복 write를 안 만든다.
+
+## Sync vs Async vs DynamoDB
+
+내가 지금 정리하는 휴리스틱:
+
+| 필요한 것 | 선택 |
+|---|---|
+| 재구성 가능, hot path, 비용 중요 | ElastiCache async |
+| Correctness 중요, write rate 낮음, microsecond read 필요 | ElastiCache sync |
+| Audit trail, key lookup 외 query, 가끔만 access | DynamoDB |
+| 큰 blob, write-once-read-many | S3 + ElastiCache에 포인터 |
+
+DynamoDB가 사라지진 않는다. Attribute로 query하거나 paginate하거나 audit해야 하면 여전히 DynamoDB. ElastiCache durability는 DynamoDB 대체재가 아니라, **DynamoDB를 *부실한 캐시로* 쓰는 걸 멈추게 해주는 변화**다.
+
+## 다음에 할 것
+
+- 내부 에이전트의 RAG step 앞에 semantic cache layer 추가. Async write, embedding-hash key, content-version 포함.
+- 한 워크플로의 작은 DynamoDB "agent scratchpad" 테이블을 Valkey cluster로 PoC 교체. 다음 state가 읽는 slot은 sync write.
+- Retry 시끄러운 Step Function 하나에 DLQ coordinator 패턴 spec 잡기. 이건 짓기 전에 짧은 설계 문서부터.
+
+마지막 캐시 작업이 어떤 워크플로 툴의 Redis였다면, 이번 발표는 다시 들여다볼 이유다. "캐시 vs 데이터베이스" 선이 방금 옮겨졌다.


### PR DESCRIPTION
AWS announced durability for ElastiCache for Valkey on June 2, 2026. Article walks through where the new sync/async durability modes change the design for someone working on AWS AI infra:

- Pattern 1: RAG semantic cache (async durability default, content-version key)
- Pattern 2: Step Functions agent workflow state — execution scratchpad, long-term memory, tool-call cache
- Pattern 3: DLQ retry coordinator with circuit-breaker (sync durability earns its keep here)
- Heuristic: when to pick sync vs async vs DynamoDB

Files:
- content/blog/2026-06-03-elasticache-durability-rag-agent-patterns.en.md
- content/blog/2026-06-03-elasticache-durability-rag-agent-patterns.ko.md

Frontmatter validation: PASSED (187 posts).