### PR TITLE
blog: Step Functions × AgentCore for async agent pipelines (en/ko)

### DIFF
--- a/content/blog/2026-06-04-step-functions-agentcore-async-pipelines.en.md
+++ b/content/blog/2026-06-04-step-functions-agentcore-async-pipelines.en.md
@@ -1,0 +1,126 @@
+---
+title: "Step Functions × AgentCore: When Your Async Pipeline Already Runs Agents"
+date: 2026-06-04T11:30:00-04:00
+author: Yoonsoo Park
+description: "AWS just shipped a native Step Functions integration for Bedrock AgentCore Runtime. If you already wrap agent calls in Lambda behind a state machine, this changes where the agent actually executes — and removes a few specific pain points that anyone running long-running agents has hit."
+categories:
+  - AWS
+  - AgentCore
+tags:
+  - step-functions
+  - bedrock
+  - agentcore
+  - async
+  - lambda
+---
+
+[AWS announced](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-step-functions-agentcore/) a native Step Functions integration for Bedrock AgentCore Runtime in June 2026. State machines can now invoke an AgentCore agent as a first-class task — no Lambda wrapper, no hand-rolled polling, no `boto3.client("bedrock-agentcore").invoke_agent_runtime` inside a Python function whose only job is to forward arguments.
+
+That sounds like a small thing. For platform teams who already run agents inside async pipelines, it isn't.
+
+## The shape we keep ending up with
+
+If you're building agentic features on AWS for a real product, the architecture converges on something close to this:
+
+```
+POST /something/runs   →  202 + requestId
+                              ↓
+                      Step Functions starts
+                              ↓
+              Lambda(call agent + write result)
+                              ↓
+                       DynamoDB updated
+                              ↓
+GET /something/runs/{id}  →  status + output
+```
+
+The state machine exists because the agent call is too slow to hold an HTTP connection open for. The Lambda exists because, until last week, that was the only way to call an agent from a state machine. The `Runnable.long_run()` / `RunnablePoll` patterns most teams end up with are all variations on the same theme: **a thin Python wrapper that calls Bedrock and returns control to the state machine.**
+
+It works. It also has four specific problems that don't go away no matter how clean your code is.
+
+## Four problems this pattern actually has
+
+### 1. Lambda's 15-minute timeout decides how long your agent can think
+
+This one is backwards. The agent's reasoning budget should be a product decision — "this action involves five tool calls and a long context, so it might take 8 minutes" — but in practice, the limit is whatever Lambda lets you do. Anything longer needs ECS, Fargate, or a chain of Lambdas that hand off state, all of which are work nobody actually wants to do.
+
+AgentCore Runtime has an 8-hour ceiling. When the state machine invokes AgentCore directly via the new `.sync` integration, the Lambda is gone, and so is the 15-minute cliff.
+
+### 2. Multi-step agent workflows fail atomically
+
+If your action does plan → fan-out tool calls → reduce → validate, all of that runs inside one agent loop, inside one Lambda. Any failure — a tool that timed out, a downstream service that returned 503, a model that produced malformed JSON on the third turn — restarts the whole thing.
+
+The state machine layer above it is useless for this, because from its perspective the Lambda either succeeded or didn't. There's no "the plan finished but the validation step blew up, retry just the validation."
+
+Once the agent calls are SF tasks, the workflow can actually be a workflow:
+
+```
+Plan(agent)
+  → Map(tool calls in parallel)
+    → Reduce(agent)
+      → Validate(agent)
+```
+
+Each step has its own retry, catch, and checkpoint. A failure in `Validate` re-runs `Validate`, not the whole chain.
+
+### 3. External job polling is a pattern everyone reimplements
+
+Textract async, Bedrock batch inference, anything with "submit job → poll for completion" — every team writes the same loop. Configurable interval, max attempts, status mapping, exit on failure. It's never quite the same code twice.
+
+`.sync` integrations let Step Functions handle the polling. The state machine submits the job and waits on the task token. AgentCore async invocations slot into the same model. The polling code stops being yours.
+
+### 4. Agent execution is invisible at the workflow layer
+
+Right now, if a multi-step agent call goes wrong, your CloudWatch logs are a wall of `{"level": "INFO", "agent": ...}` lines and you're greping for the failure. Per-step cost? Aggregated at the Lambda level. X-Ray traces? They cover the Lambda, not the agent's internal turns.
+
+When the agent invocation is a state machine task, the workflow execution view shows it as a step. Cost attributes per step. X-Ray traces span the agent call. Failure modes have names again.
+
+## What changes with native AgentCore integration
+
+Concretely:
+
+| Before | After |
+|---|---|
+| `LambdaInvoke` task → Python handler → `bedrock-agentcore.invoke_agent_runtime` | Native `BedrockAgentCore: InvokeAgentRuntime.sync` task |
+| 15-min Lambda timeout | 8-hour AgentCore Runtime timeout |
+| Agent loop runs inside Lambda; failure restarts everything | Plan/fan-out/reduce/validate as separate SF steps with independent retry |
+| Hand-written `poll_run()` with `interval_seconds` and `max_poll_attempts` | SF `.sync` integration handles polling |
+| Per-Lambda CloudWatch logs | Per-step SF execution view + X-Ray |
+| Human-in-the-loop bolted on with custom DynamoDB state | `waitForTaskToken` + agent task |
+
+The last row is worth pausing on. A lot of agentic features in regulated industries need a human approval step somewhere — "the agent drafted this loan memo, but a human signs off before it goes out." The way you used to build that was: agent writes draft to DynamoDB, separate API marks it approved, separate Lambda picks it up, separate state machine resumes. With `waitForTaskToken`, the state machine literally pauses on a step, an external system calls back with the token, and the agent picks up where it left off. The approval flow becomes a single state diagram instead of three coupled services.
+
+## Decision tree — should you actually migrate?
+
+Not every async agent call benefits from this.
+
+✅ **Worth migrating** if:
+- You already run agents inside Step Functions via Lambda
+- Agent calls are long-running (>5 min) or you've felt the 15-min ceiling
+- You have multi-step agent workflows where partial retry would help
+- You have external-job polling patterns (Textract async, batch inference, etc.) — these are the lowest-risk first move; the polling code straight-up disappears
+- You need human-in-the-loop and you've been building it manually
+
+⚠️ **Cost-first before migrating** if:
+- You're using a direct SDK (Strands, raw Bedrock) inside Lambda. Moving to AgentCore Runtime is its own deployment and operational change. The integration assumes you've already adopted AgentCore.
+- Your async pipeline is small (one Lambda, one DynamoDB write) and the rewrite is bigger than the win.
+
+❌ **Don't bother** if:
+- The agent call is short (< 1 min), single-turn, and never fails interestingly. Lambda + SDK is fine.
+- You don't actually have a state machine. Adding one to use this integration is putting the cart before the horse.
+
+## Pitfalls to expect
+
+- **Step Functions state size limit is 256 KB.** This already affects anyone passing large documents through SF. With agent inputs/outputs in the loop, plan to keep payloads in S3 and pass references. Existing patterns work; the integration doesn't relax the limit.
+- **AgentCore Runtime region availability.** As of launch, AgentCore is in fewer regions than Step Functions. If your product runs in `me-central-1` or `ap-northeast-1`, check before you redesign. Cross-region AgentCore invocation from SF is a separate question.
+- **Cold start moves, it doesn't disappear.** You stop paying for Lambda cold start; you start paying for AgentCore Runtime cold start. The numbers aren't identical and they're worth measuring on a real workload before declaring victory.
+- **IAM gets a new principal in the trust chain.** The state machine's execution role now needs `bedrock-agentcore:InvokeAgentRuntime`. If your platform has tag-based access controls (we do — `IntelligenceRegistryAccess` style tags), the state machine role needs the right tag, not just the Lambda role.
+- **Observability changes shape.** Existing dashboards keyed on Lambda function names will go quiet on the agent path. Plan a parallel set of SF execution and AgentCore metrics before flipping traffic.
+
+## What this actually means
+
+Up until this integration, "where does the agent execute" was a question with a frustrating answer: inside a Lambda, because that's the only thing your workflow engine knew how to invoke. The execution location was a side effect of the orchestration choice, not a design decision.
+
+Native AgentCore-as-task changes that. Agent execution becomes something you can place where it belongs — long-running, observable, retryable at the step granularity that actually matches your workflow. The orchestrator stops being a thin wrapper and becomes the actual orchestrator.
+
+If you've been deferring an agentic feature because "the async story is messy," it's worth a fresh look. The async story just got a lot less messy.

--- a/content/blog/2026-06-04-step-functions-agentcore-async-pipelines.ko.md
+++ b/content/blog/2026-06-04-step-functions-agentcore-async-pipelines.ko.md
@@ -1,8 +1,8 @@
 ---
-title: "Step Functions × AgentCore: 이미 에이전트를 async로 돌리고 있다면"
+title: "Step Functions × AgentCore: 이미 async 파이프라인에서 에이전트를 돌리고 있다면"
 date: 2026-06-04T11:30:00-04:00
 author: Yoonsoo Park
-description: "AWS가 Step Functions에서 Bedrock AgentCore Runtime을 native task로 호출할 수 있게 했다. State machine 뒤에 Lambda로 agent를 감싸고 있던 팀이라면, 에이전트가 실제로 어디서 실행되는지 자체가 바뀌고 — 그동안 다들 한 번씩은 밟은 통증 몇 개가 사라진다."
+description: "AWS가 Step Functions에서 Bedrock AgentCore Runtime을 네이티브 태스크로 호출할 수 있게 했다. 이미 state machine 뒤에서 Lambda로 에이전트를 감싸 돌리고 있다면, 에이전트가 실제로 어디서 실행되는지부터 달라지고, 긴 실행 시간·재시도·폴링 같은 골칫거리도 꽤 정리된다."
 categories:
   - AWS
   - AgentCore
@@ -14,13 +14,13 @@ tags:
   - lambda
 ---
 
-[AWS가 2026년 6월](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-step-functions-agentcore/) Step Functions에서 Bedrock AgentCore Runtime을 native task로 호출할 수 있는 통합을 발표했다. State machine이 AgentCore agent를 first-class task로 invoke한다 — Lambda wrapper 없이, 직접 짠 polling 없이, "그냥 인자 forwarding이 일인" Python 함수 안에서 `boto3.client("bedrock-agentcore").invoke_agent_runtime`을 호출하지 않고.
+[AWS는 2026년 6월](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-step-functions-agentcore/) Step Functions에서 Bedrock AgentCore Runtime을 네이티브 태스크로 호출할 수 있는 통합을 발표했다. 이제 state machine에서 AgentCore 에이전트를 1급 태스크처럼 직접 호출할 수 있다. Lambda 래퍼도 필요 없고, 직접 폴링 루프를 짤 필요도 없고, 인자만 받아 `boto3.client("bedrock-agentcore").invoke_agent_runtime`으로 넘겨주는 얇은 Python 함수도 굳이 둘 이유가 없다.
 
-작은 변화처럼 들리는데, 실제 제품에서 에이전트를 async pipeline으로 굴리는 platform 팀에는 작지 않다.
+겉보기에는 자잘한 개선처럼 보일 수 있다. 하지만 실제 제품에서 에이전트를 async 파이프라인에 올려 운용하는 플랫폼 팀에게는 그렇지 않다.
 
-## 다들 결국 같은 모양으로 수렴한다
+## 결국 다들 비슷한 구조로 간다
 
-AWS 위에서 agentic feature를 진지하게 만들면 아키텍처가 대체로 이렇게 수렴한다:
+AWS 위에서 agentic feature를 실제 서비스에 붙이기 시작하면, 아키텍처는 대체로 이런 형태로 수렴한다.
 
 ```
 POST /something/runs   →  202 + requestId
@@ -34,25 +34,25 @@ POST /something/runs   →  202 + requestId
 GET /something/runs/{id}  →  status + output
 ```
 
-State machine이 있는 이유는 agent 호출이 너무 길어서 HTTP connection을 잡고 있을 수 없어서. Lambda가 있는 이유는 지난주까지 state machine에서 agent를 호출하는 방법이 그것밖에 없어서. 우리가 다 한 번씩 짜본 `Runnable.long_run()` / `RunnablePoll` 패턴들은 결국 다 같은 말을 한다 — **Bedrock 호출하고 state machine에 control 돌려주는 얇은 Python wrapper**.
+State machine이 필요한 이유는 agent 호출이 길어서 HTTP 연결을 계속 붙잡고 있을 수 없기 때문이다. Lambda가 끼어 있는 이유는, 지난주까지만 해도 state machine에서 에이전트를 호출하는 가장 현실적인 방법이 그것뿐이었기 때문이다. 많은 팀이 결국 도달하는 `Runnable.long_run()` / `RunnablePoll` 패턴도 본질적으로는 같다. **Bedrock을 한 번 호출하고 제어권을 state machine으로 돌려주는 얇은 Python 래퍼**일 뿐이다.
 
-돌아가긴 한다. 그런데 코드를 아무리 깔끔하게 짜도 사라지지 않는 문제 4개가 있다.
+이 구조는 분명 동작한다. 다만 코드 스타일을 아무리 정리해도 사라지지 않는 문제가 네 가지 있다.
 
-## 이 패턴이 실제로 가진 4가지 문제
+## 이 패턴이 실제로 안고 있는 네 가지 문제
 
-### 1. Lambda 15분 timeout이 에이전트 사고 시간을 결정함
+### 1. Lambda의 15분 제한이 에이전트의 사고 시간을 정한다
 
-이게 가장 거꾸로 된 부분이다. 에이전트의 reasoning budget은 제품 결정이어야 한다 — "이 action은 tool call 5번에 긴 context라서 8분 걸릴 수 있다." 그런데 현실에서는 Lambda가 허용하는 시간이 한도다. 그보다 길면 ECS, Fargate, 아니면 state를 넘기는 Lambda 체인 — 누구도 실제로 하고 싶어 하지 않는 작업.
+이건 순서가 거꾸로다. 에이전트가 얼마나 오래 추론할 수 있는지는 제품 요구가 결정해야 한다. 예를 들어 "이 작업은 tool call이 다섯 번 돌고 context도 길어서 8분 정도 걸릴 수 있다" 같은 식이다. 그런데 현실에서는 Lambda가 허용하는 시간이 곧 한계가 된다. 15분을 넘기면 ECS나 Fargate로 옮기거나, 상태를 넘겨 가며 Lambda를 이어 붙여야 한다. 솔직히 누구도 반가워할 작업은 아니다.
 
-AgentCore Runtime은 8시간까지 허용한다. State machine이 새 `.sync` 통합으로 AgentCore를 직접 invoke하면 Lambda가 사라지고, 15분 cliff도 같이 사라진다.
+AgentCore Runtime은 최대 8시간까지 실행할 수 있다. 새 `.sync` 통합으로 state machine이 AgentCore를 직접 호출하면 Lambda가 빠지고, 15분 제한도 함께 사라진다.
 
-### 2. Multi-step agent workflow는 atomic하게 실패한다
+### 2. 여러 단계로 이뤄진 agent workflow가 통째로 실패한다
 
-Action 하나가 plan → fan-out tool calls → reduce → validate를 하면, 그게 전부 agent loop 하나, Lambda 하나 안에서 돈다. Tool 하나가 timeout이든, downstream service가 503을 뱉든, 모델이 세 번째 turn에서 malformed JSON을 만들든 — 어떤 실패든 처음부터 다시 돌린다.
+하나의 작업이 plan → fan-out tool calls → reduce → validate 순서로 진행된다고 해보자. 지금 구조에서는 이 전체가 하나의 agent loop 안에서, 하나의 Lambda 안에서 실행된다. 도중에 tool 하나가 timeout 나거나, downstream service가 503을 반환하거나, 모델이 세 번째 턴에서 malformed JSON을 만들면 어떻게 될까? 결국 처음부터 전부 다시 돌려야 한다.
 
-위에 있는 state machine layer는 도움이 안 된다. SF 입장에서는 Lambda가 성공하거나 실패하거나 둘 중 하나니까. "plan은 끝났는데 validation이 터졌으니 validation만 retry"가 없다.
+위에 얹힌 state machine은 여기서 큰 도움이 되지 않는다. Step Functions 입장에서는 Lambda가 성공했는지 실패했는지만 보이기 때문이다. "plan은 끝났고 validate에서만 실패했으니 validate만 다시 돌리자" 같은 선택지가 없다.
 
-Agent 호출이 SF task가 되면, workflow가 진짜 workflow가 된다:
+하지만 agent 호출이 Step Functions 태스크가 되면, 비로소 workflow를 workflow답게 나눌 수 있다.
 
 ```
 Plan(agent)
@@ -61,66 +61,66 @@ Plan(agent)
       → Validate(agent)
 ```
 
-각 step이 자기 retry, catch, checkpoint를 갖는다. `Validate`에서 실패하면 `Validate`만 다시 돈다.
+각 단계가 자기만의 retry, catch, checkpoint를 가진다. `Validate`에서 실패하면 전체를 다시 시작하는 대신 `Validate`만 재실행하면 된다.
 
-### 3. External job polling은 매번 다시 짠다
+### 3. 외부 작업 폴링 코드를 팀마다 매번 다시 쓴다
 
-Textract async, Bedrock batch inference, "job 제출 → 완료까지 polling"이 있는 모든 것 — 모든 팀이 같은 loop를 다시 짠다. Interval, max attempts, status mapping, 실패 시 exit. 매번 미묘하게 다르다.
+Textract async, Bedrock batch inference처럼 "작업 제출 → 완료될 때까지 폴링"이 필요한 서비스는 정말 많다. 그런데 이상하게도 이 루프는 팀마다 늘 새로 만든다. polling interval, 최대 시도 횟수, 상태값 매핑, 실패 처리까지. 비슷한데 완전히 같지는 않은 코드가 곳곳에 쌓인다.
 
-`.sync` 통합은 polling을 Step Functions가 처리한다. State machine이 job을 제출하고 task token에서 기다린다. AgentCore async invocation도 같은 모델로 들어온다. Polling 코드가 더 이상 우리 것이 아니다.
+`.sync` 통합을 쓰면 이 폴링을 Step Functions가 맡는다. State machine이 작업을 제출하고 완료를 기다리는 흐름을 프레임워크 차원에서 처리해 준다. AgentCore의 async invocation도 같은 모델에 들어온다. 다시 말해, 폴링 코드는 더 이상 애플리케이션 코드가 아니다.
 
-### 4. Agent 실행이 workflow 레이어에서 안 보인다
+### 4. workflow 레이어에서는 agent 실행이 잘 보이지 않는다
 
-지금은 multi-step agent 호출이 잘못되면 CloudWatch log가 `{"level": "INFO", "agent": ...}`로 도배되고, 그 안에서 grep으로 실패를 찾는다. Step별 cost? Lambda 단위로만 집계된다. X-Ray trace? Lambda는 보이지만 agent 내부 turn은 안 보인다.
+지금 구조에서 여러 단계를 거치는 agent 호출이 꼬이면, CloudWatch 로그에 `{"level": "INFO", "agent": ...}` 같은 줄만 빽빽하게 쌓이고 그 안에서 실패 지점을 grep으로 찾아야 한다. 단계별 비용은 Lambda 단위로만 뭉뚱그려 보이고, X-Ray trace도 Lambda까지만 보일 뿐 agent 내부 턴까지는 잘 드러나지 않는다.
 
-Agent invocation이 state machine task가 되면, workflow execution view에 step으로 떠오른다. Step별 cost, X-Ray trace가 agent 호출까지 걸린다. 실패 모드에 다시 이름이 생긴다.
+반대로 agent invocation 자체가 state machine 태스크가 되면, workflow execution view에서 그 호출이 하나의 단계로 드러난다. 단계별 비용을 나눠 볼 수 있고, X-Ray trace도 agent 호출까지 이어진다. 실패 유형도 다시 구체적인 이름을 갖게 된다.
 
-## Native AgentCore 통합이 바꾸는 것
+## 네이티브 AgentCore 통합으로 달라지는 점
 
-구체적으로:
+정리하면 이렇다.
 
 | Before | After |
 |---|---|
-| `LambdaInvoke` task → Python handler → `bedrock-agentcore.invoke_agent_runtime` | Native `BedrockAgentCore: InvokeAgentRuntime.sync` task |
+| `LambdaInvoke` task → Python handler → `bedrock-agentcore.invoke_agent_runtime` | 네이티브 `BedrockAgentCore: InvokeAgentRuntime.sync` task |
 | 15분 Lambda timeout | 8시간 AgentCore Runtime timeout |
-| Agent loop가 Lambda 안에서 돔; 실패하면 처음부터 | Plan/fan-out/reduce/validate가 SF step으로 분리, 독립 retry |
-| 직접 짠 `poll_run()` + `interval_seconds`, `max_poll_attempts` | SF `.sync` 통합이 polling 처리 |
-| Per-Lambda CloudWatch log | Per-step SF execution view + X-Ray |
-| Custom DynamoDB state로 만든 human-in-the-loop | `waitForTaskToken` + agent task |
+| Agent loop가 Lambda 안에서 돌고, 실패하면 처음부터 다시 실행 | plan/fan-out/reduce/validate를 SF 단계로 나누고 각각 독립적으로 retry |
+| 직접 작성한 `poll_run()` + `interval_seconds`, `max_poll_attempts` | SF `.sync` 통합이 폴링 처리 |
+| Lambda 중심의 CloudWatch 로그 | 단계별 SF execution view + X-Ray |
+| 직접 조합한 DynamoDB 상태 기반 human-in-the-loop | `waitForTaskToken` + agent task |
 
-마지막 줄은 잠깐 멈출 만하다. 규제 산업의 agentic feature는 거의 다 어디선가 사람 승인 step이 필요하다 — "에이전트가 loan memo 초안을 썼는데, 나가기 전에 사람이 sign off." 예전에 이걸 만드는 방식: agent가 draft를 DynamoDB에 쓰고, 별도 API가 approved로 mark하고, 별도 Lambda가 picking up하고, 별도 state machine이 resume. `waitForTaskToken`으로는 state machine이 그 step에서 그냥 멈춰 있고, 외부 시스템이 token으로 callback하면 agent가 이어서 간다. Approval flow가 service 3개의 coupling이 아니라 state diagram 하나가 된다.
+특히 마지막 줄은 한 번 짚고 넘어갈 만하다. 규제 산업의 agentic feature에는 중간 어딘가에 사람 승인 단계가 들어가는 경우가 많다. 예를 들어 "에이전트가 대출 메모 초안을 만들고, 외부로 나가기 전에 사람이 최종 승인한다" 같은 흐름이다. 예전에는 에이전트가 초안을 DynamoDB에 저장하고, 별도 API가 승인 상태로 바꾸고, 다른 Lambda가 그걸 주워 가고, 또 다른 state machine이 이어서 실행하는 식으로 얽히기 쉬웠다. `waitForTaskToken`을 쓰면 state machine이 특정 단계에서 그대로 멈춰 있다가, 외부 시스템이 토큰으로 콜백을 보내는 순간 다시 이어서 진행할 수 있다. 승인 흐름이 서로 얽힌 세 개의 서비스가 아니라 하나의 state diagram으로 정리된다.
 
-## Decision tree — 진짜 migrate해야 하나?
+## 그래서, 실제로 옮길 만한가?
 
-모든 async agent 호출이 이걸 도입해서 이득은 아니다.
+모든 async agent 호출이 이 통합 덕을 보는 것은 아니다.
 
-✅ **Migrate할 만함:**
-- 이미 Step Functions 안에서 Lambda로 agent를 돌리고 있음
-- Agent 호출이 길거나 (>5분) 15분 cliff를 느꼈음
-- Multi-step agent workflow가 있고 partial retry가 도움 됨
-- External job polling 패턴이 있음 (Textract async, batch inference 등) — 가장 risk 작은 첫 이전 대상. Polling 코드가 그냥 사라진다.
-- Human-in-the-loop가 필요했고 그동안 손으로 만들어왔음
+✅ **옮길 가치가 큰 경우**
+- 이미 Step Functions 안에서 Lambda를 통해 agent를 실행하고 있다
+- Agent 호출이 길거나(5분 이상), 15분 제한에 걸려 본 적이 있다
+- 여러 단계로 나뉜 agent workflow가 있고, 부분 재시도가 큰 도움이 된다
+- 외부 작업 폴링 패턴이 있다(Textract async, batch inference 등) — 가장 부담 없이 옮기기 좋은 첫 대상이다. 폴링 코드가 그대로 사라진다
+- Human-in-the-loop가 필요해서 지금까지 직접 구현해 왔다
 
-⚠️ **Migrate 전에 비용 먼저 따져야:**
-- Lambda 안에서 직접 SDK (Strands, raw Bedrock)를 쓰고 있음. AgentCore Runtime으로 옮기는 것 자체가 별개의 배포/운영 변화다. 이 통합은 이미 AgentCore를 채택했다고 가정한다.
-- Async pipeline이 작음 (Lambda 1개, DynamoDB write 1개). 다시 짜는 비용이 얻는 것보다 큼.
+⚠️ **옮기기 전에 비용부터 따져볼 경우**
+- Lambda 안에서 SDK(Strands, raw Bedrock 등)를 직접 쓰고 있다. AgentCore Runtime으로 옮기는 것 자체가 별도의 배포·운영 변화다. 이 통합은 이미 AgentCore를 도입했다는 전제에서 가장 빛난다
+- Async pipeline이 아주 단순하다(Lambda 하나, DynamoDB write 하나). 이 경우에는 재작성 비용이 이득보다 더 클 수 있다
 
-❌ **굳이 안 해도 됨:**
-- Agent 호출이 짧고 (< 1분), single-turn이고, 흥미롭게 실패하지 않음. Lambda + SDK로 충분.
-- 애초에 state machine이 없음. 이 통합 쓰려고 SF를 도입하는 건 본말전도.
+❌ **굳이 건드리지 않아도 되는 경우**
+- Agent 호출이 짧고(1분 미만), single-turn이며, 실패 양상도 단순하다. 이 정도면 Lambda + SDK로도 충분하다
+- 애초에 state machine이 없다. 이 통합 하나를 쓰려고 Step Functions부터 도입하는 건 순서가 뒤바뀐 선택이다
 
-## 예상되는 함정
+## 미리 예상할 만한 함정
 
-- **Step Functions state size 256 KB 한도.** SF로 큰 document 흘리는 팀은 이미 알고 있는 문제. Agent input/output까지 끼면 payload는 S3에 두고 reference만 넘기는 패턴 필수. 이 통합이 한도를 풀어주지는 않는다.
-- **AgentCore Runtime region availability.** 발표 시점 기준 AgentCore는 Step Functions보다 리전이 적다. `me-central-1`이나 `ap-northeast-1`에서 굴러가는 제품이라면 재설계 전에 확인 필요. Cross-region AgentCore invocation from SF는 별도 질문.
-- **Cold start는 사라지는 게 아니라 이동한다.** Lambda cold start는 안 내지만 AgentCore Runtime cold start를 낸다. 숫자가 같지 않고, 실제 workload에서 측정해보고 victory 선언해야 한다.
-- **IAM trust chain에 새 principal이 들어온다.** State machine execution role이 `bedrock-agentcore:InvokeAgentRuntime`이 필요해진다. Tag-based access control이 있는 platform이라면 (우리도 그렇다 — `IntelligenceRegistryAccess` 스타일) state machine role이 올바른 tag를 가져야 한다. Lambda role만 있는 게 아니라.
-- **Observability 모양이 바뀐다.** Lambda function name으로 dashboard 짜둔 게 있다면 agent path에서 조용해진다. Traffic flip 전에 SF execution + AgentCore metric으로 parallel dashboard 준비해두는 편.
+- **Step Functions state size는 256 KB로 제한된다.** 이미 큰 문서를 SF 안에서 넘기는 팀이라면 익숙한 제약일 것이다. Agent input/output까지 흐름에 포함되면 payload는 S3에 두고 참조만 넘기는 방식이 사실상 필수다. 이번 통합이 이 한도를 완화해 주지는 않는다.
+- **AgentCore Runtime의 리전 지원 범위가 더 좁다.** 출시 시점 기준으로 AgentCore는 Step Functions보다 지원 리전이 적다. 제품이 `me-central-1`이나 `ap-northeast-1`에서 돌아간다면 아키텍처를 바꾸기 전에 먼저 확인해야 한다. Step Functions에서 cross-region으로 AgentCore를 호출할 수 있는지는 또 다른 문제다.
+- **Cold start는 사라지는 게 아니라 위치만 바뀐다.** Lambda cold start 비용은 줄지만, 대신 AgentCore Runtime cold start를 보게 된다. 둘은 성격이 같지 않으니 실제 workload로 측정해 보기 전에는 섣불리 결론 내리지 않는 편이 좋다.
+- **IAM trust chain에 새로운 주체가 추가된다.** 이제 state machine execution role에 `bedrock-agentcore:InvokeAgentRuntime` 권한이 필요하다. 플랫폼에서 tag-based access control을 쓴다면(예: `IntelligenceRegistryAccess` 스타일 태그) Lambda role뿐 아니라 state machine role에도 올바른 태그가 붙어 있어야 한다.
+- **관측 지점의 모양이 달라진다.** 지금까지 Lambda 함수 이름 기준으로 대시보드를 짜 두었다면, agent 경로에서는 그 지표가 잠잠해질 수 있다. 트래픽을 전환하기 전에 Step Functions execution과 AgentCore metrics를 기준으로 새 대시보드를 함께 준비해 두는 편이 안전하다.
 
-## 결국 이 발표가 말하는 것
+## 결국 이 발표가 의미하는 것
 
-이 통합 전까지 "에이전트가 어디서 실행되는가"는 답하기 짜증나는 질문이었다 — Lambda 안에서, 왜냐하면 workflow engine이 invoke할 줄 아는 게 그것밖에 없으니까. 실행 위치는 디자인 결정이 아니라 orchestration 선택의 부작용이었다.
+지금까지는 "에이전트가 어디서 실행되는가?"라는 질문에 답하기가 애매했다. 대개는 "Lambda 안에서"라고 답할 수밖에 없었고, 그 이유도 단순했다. workflow engine이 원래 그렇게밖에 호출할 수 없었기 때문이다. 즉, 실행 위치는 설계 결정이라기보다 orchestration 방식이 만들어 낸 부작용에 가까웠다.
 
-Native AgentCore-as-task가 그걸 바꾼다. Agent 실행이 제자리에 둘 수 있는 무언가가 된다 — long-running, observable, workflow에 맞는 step 단위로 retry 가능. Orchestrator가 얇은 wrapper가 아니라 진짜 orchestrator가 된다.
+하지만 AgentCore를 state machine 태스크로 직접 다룰 수 있게 되면서 상황이 달라졌다. 이제 agent 실행을 더 자연스러운 자리에 놓을 수 있다. 오래 실행될 수 있고, 관측 가능하고, 실제 workflow 구조에 맞춰 단계별로 재시도할 수 있는 자리 말이다. Orchestrator도 더 이상 얇은 래퍼에 머무르지 않고, 진짜 orchestrator 역할을 하게 된다.
 
-"async story가 지저분해서" 미뤄둔 agentic feature가 있다면, 다시 볼 만하다. Async story가 꽤 덜 지저분해졌다.
+그동안 "async 쪽이 너무 지저분해서" agentic feature를 미뤄 왔다면, 이제는 다시 한 번 검토해 볼 만하다. 적어도 예전보다 훨씬 덜 지저분해졌다.

--- a/content/blog/2026-06-04-step-functions-agentcore-async-pipelines.ko.md
+++ b/content/blog/2026-06-04-step-functions-agentcore-async-pipelines.ko.md
@@ -1,0 +1,126 @@
+---
+title: "Step Functions × AgentCore: 이미 에이전트를 async로 돌리고 있다면"
+date: 2026-06-04T11:30:00-04:00
+author: Yoonsoo Park
+description: "AWS가 Step Functions에서 Bedrock AgentCore Runtime을 native task로 호출할 수 있게 했다. State machine 뒤에 Lambda로 agent를 감싸고 있던 팀이라면, 에이전트가 실제로 어디서 실행되는지 자체가 바뀌고 — 그동안 다들 한 번씩은 밟은 통증 몇 개가 사라진다."
+categories:
+  - AWS
+  - AgentCore
+tags:
+  - step-functions
+  - bedrock
+  - agentcore
+  - async
+  - lambda
+---
+
+[AWS가 2026년 6월](https://aws.amazon.com/about-aws/whats-new/2026/06/aws-step-functions-agentcore/) Step Functions에서 Bedrock AgentCore Runtime을 native task로 호출할 수 있는 통합을 발표했다. State machine이 AgentCore agent를 first-class task로 invoke한다 — Lambda wrapper 없이, 직접 짠 polling 없이, "그냥 인자 forwarding이 일인" Python 함수 안에서 `boto3.client("bedrock-agentcore").invoke_agent_runtime`을 호출하지 않고.
+
+작은 변화처럼 들리는데, 실제 제품에서 에이전트를 async pipeline으로 굴리는 platform 팀에는 작지 않다.
+
+## 다들 결국 같은 모양으로 수렴한다
+
+AWS 위에서 agentic feature를 진지하게 만들면 아키텍처가 대체로 이렇게 수렴한다:
+
+```
+POST /something/runs   →  202 + requestId
+                              ↓
+                      Step Functions 시작
+                              ↓
+              Lambda(agent 호출 + 결과 저장)
+                              ↓
+                       DynamoDB 업데이트
+                              ↓
+GET /something/runs/{id}  →  status + output
+```
+
+State machine이 있는 이유는 agent 호출이 너무 길어서 HTTP connection을 잡고 있을 수 없어서. Lambda가 있는 이유는 지난주까지 state machine에서 agent를 호출하는 방법이 그것밖에 없어서. 우리가 다 한 번씩 짜본 `Runnable.long_run()` / `RunnablePoll` 패턴들은 결국 다 같은 말을 한다 — **Bedrock 호출하고 state machine에 control 돌려주는 얇은 Python wrapper**.
+
+돌아가긴 한다. 그런데 코드를 아무리 깔끔하게 짜도 사라지지 않는 문제 4개가 있다.
+
+## 이 패턴이 실제로 가진 4가지 문제
+
+### 1. Lambda 15분 timeout이 에이전트 사고 시간을 결정함
+
+이게 가장 거꾸로 된 부분이다. 에이전트의 reasoning budget은 제품 결정이어야 한다 — "이 action은 tool call 5번에 긴 context라서 8분 걸릴 수 있다." 그런데 현실에서는 Lambda가 허용하는 시간이 한도다. 그보다 길면 ECS, Fargate, 아니면 state를 넘기는 Lambda 체인 — 누구도 실제로 하고 싶어 하지 않는 작업.
+
+AgentCore Runtime은 8시간까지 허용한다. State machine이 새 `.sync` 통합으로 AgentCore를 직접 invoke하면 Lambda가 사라지고, 15분 cliff도 같이 사라진다.
+
+### 2. Multi-step agent workflow는 atomic하게 실패한다
+
+Action 하나가 plan → fan-out tool calls → reduce → validate를 하면, 그게 전부 agent loop 하나, Lambda 하나 안에서 돈다. Tool 하나가 timeout이든, downstream service가 503을 뱉든, 모델이 세 번째 turn에서 malformed JSON을 만들든 — 어떤 실패든 처음부터 다시 돌린다.
+
+위에 있는 state machine layer는 도움이 안 된다. SF 입장에서는 Lambda가 성공하거나 실패하거나 둘 중 하나니까. "plan은 끝났는데 validation이 터졌으니 validation만 retry"가 없다.
+
+Agent 호출이 SF task가 되면, workflow가 진짜 workflow가 된다:
+
+```
+Plan(agent)
+  → Map(tool calls in parallel)
+    → Reduce(agent)
+      → Validate(agent)
+```
+
+각 step이 자기 retry, catch, checkpoint를 갖는다. `Validate`에서 실패하면 `Validate`만 다시 돈다.
+
+### 3. External job polling은 매번 다시 짠다
+
+Textract async, Bedrock batch inference, "job 제출 → 완료까지 polling"이 있는 모든 것 — 모든 팀이 같은 loop를 다시 짠다. Interval, max attempts, status mapping, 실패 시 exit. 매번 미묘하게 다르다.
+
+`.sync` 통합은 polling을 Step Functions가 처리한다. State machine이 job을 제출하고 task token에서 기다린다. AgentCore async invocation도 같은 모델로 들어온다. Polling 코드가 더 이상 우리 것이 아니다.
+
+### 4. Agent 실행이 workflow 레이어에서 안 보인다
+
+지금은 multi-step agent 호출이 잘못되면 CloudWatch log가 `{"level": "INFO", "agent": ...}`로 도배되고, 그 안에서 grep으로 실패를 찾는다. Step별 cost? Lambda 단위로만 집계된다. X-Ray trace? Lambda는 보이지만 agent 내부 turn은 안 보인다.
+
+Agent invocation이 state machine task가 되면, workflow execution view에 step으로 떠오른다. Step별 cost, X-Ray trace가 agent 호출까지 걸린다. 실패 모드에 다시 이름이 생긴다.
+
+## Native AgentCore 통합이 바꾸는 것
+
+구체적으로:
+
+| Before | After |
+|---|---|
+| `LambdaInvoke` task → Python handler → `bedrock-agentcore.invoke_agent_runtime` | Native `BedrockAgentCore: InvokeAgentRuntime.sync` task |
+| 15분 Lambda timeout | 8시간 AgentCore Runtime timeout |
+| Agent loop가 Lambda 안에서 돔; 실패하면 처음부터 | Plan/fan-out/reduce/validate가 SF step으로 분리, 독립 retry |
+| 직접 짠 `poll_run()` + `interval_seconds`, `max_poll_attempts` | SF `.sync` 통합이 polling 처리 |
+| Per-Lambda CloudWatch log | Per-step SF execution view + X-Ray |
+| Custom DynamoDB state로 만든 human-in-the-loop | `waitForTaskToken` + agent task |
+
+마지막 줄은 잠깐 멈출 만하다. 규제 산업의 agentic feature는 거의 다 어디선가 사람 승인 step이 필요하다 — "에이전트가 loan memo 초안을 썼는데, 나가기 전에 사람이 sign off." 예전에 이걸 만드는 방식: agent가 draft를 DynamoDB에 쓰고, 별도 API가 approved로 mark하고, 별도 Lambda가 picking up하고, 별도 state machine이 resume. `waitForTaskToken`으로는 state machine이 그 step에서 그냥 멈춰 있고, 외부 시스템이 token으로 callback하면 agent가 이어서 간다. Approval flow가 service 3개의 coupling이 아니라 state diagram 하나가 된다.
+
+## Decision tree — 진짜 migrate해야 하나?
+
+모든 async agent 호출이 이걸 도입해서 이득은 아니다.
+
+✅ **Migrate할 만함:**
+- 이미 Step Functions 안에서 Lambda로 agent를 돌리고 있음
+- Agent 호출이 길거나 (>5분) 15분 cliff를 느꼈음
+- Multi-step agent workflow가 있고 partial retry가 도움 됨
+- External job polling 패턴이 있음 (Textract async, batch inference 등) — 가장 risk 작은 첫 이전 대상. Polling 코드가 그냥 사라진다.
+- Human-in-the-loop가 필요했고 그동안 손으로 만들어왔음
+
+⚠️ **Migrate 전에 비용 먼저 따져야:**
+- Lambda 안에서 직접 SDK (Strands, raw Bedrock)를 쓰고 있음. AgentCore Runtime으로 옮기는 것 자체가 별개의 배포/운영 변화다. 이 통합은 이미 AgentCore를 채택했다고 가정한다.
+- Async pipeline이 작음 (Lambda 1개, DynamoDB write 1개). 다시 짜는 비용이 얻는 것보다 큼.
+
+❌ **굳이 안 해도 됨:**
+- Agent 호출이 짧고 (< 1분), single-turn이고, 흥미롭게 실패하지 않음. Lambda + SDK로 충분.
+- 애초에 state machine이 없음. 이 통합 쓰려고 SF를 도입하는 건 본말전도.
+
+## 예상되는 함정
+
+- **Step Functions state size 256 KB 한도.** SF로 큰 document 흘리는 팀은 이미 알고 있는 문제. Agent input/output까지 끼면 payload는 S3에 두고 reference만 넘기는 패턴 필수. 이 통합이 한도를 풀어주지는 않는다.
+- **AgentCore Runtime region availability.** 발표 시점 기준 AgentCore는 Step Functions보다 리전이 적다. `me-central-1`이나 `ap-northeast-1`에서 굴러가는 제품이라면 재설계 전에 확인 필요. Cross-region AgentCore invocation from SF는 별도 질문.
+- **Cold start는 사라지는 게 아니라 이동한다.** Lambda cold start는 안 내지만 AgentCore Runtime cold start를 낸다. 숫자가 같지 않고, 실제 workload에서 측정해보고 victory 선언해야 한다.
+- **IAM trust chain에 새 principal이 들어온다.** State machine execution role이 `bedrock-agentcore:InvokeAgentRuntime`이 필요해진다. Tag-based access control이 있는 platform이라면 (우리도 그렇다 — `IntelligenceRegistryAccess` 스타일) state machine role이 올바른 tag를 가져야 한다. Lambda role만 있는 게 아니라.
+- **Observability 모양이 바뀐다.** Lambda function name으로 dashboard 짜둔 게 있다면 agent path에서 조용해진다. Traffic flip 전에 SF execution + AgentCore metric으로 parallel dashboard 준비해두는 편.
+
+## 결국 이 발표가 말하는 것
+
+이 통합 전까지 "에이전트가 어디서 실행되는가"는 답하기 짜증나는 질문이었다 — Lambda 안에서, 왜냐하면 workflow engine이 invoke할 줄 아는 게 그것밖에 없으니까. 실행 위치는 디자인 결정이 아니라 orchestration 선택의 부작용이었다.
+
+Native AgentCore-as-task가 그걸 바꾼다. Agent 실행이 제자리에 둘 수 있는 무언가가 된다 — long-running, observable, workflow에 맞는 step 단위로 retry 가능. Orchestrator가 얇은 wrapper가 아니라 진짜 orchestrator가 된다.
+
+"async story가 지저분해서" 미뤄둔 agentic feature가 있다면, 다시 볼 만하다. Async story가 꽤 덜 지저분해졌다.


### PR DESCRIPTION
AWS의 Step Functions × Bedrock AgentCore native integration (2026-06) 발표를 platform 팀 관점에서 분석.

기존 "SF + Lambda + agent SDK" async 패턴이 가진 4가지 통증 (Lambda 15분 cliff, atomic 실패, 직접 짠 polling, workflow 레이어 invisibility)을 native AgentCore task가 어떻게 해결하는지 + decision tree + 예상 함정.

Files:
- `content/blog/2026-06-04-step-functions-agentcore-async-pipelines.en.md`
- `content/blog/2026-06-04-step-functions-agentcore-async-pipelines.ko.md`

Frontmatter validation: PASSED (187 posts)