### PR TITLE
fix: quote AgentCore overview title (YAML build error)

### DIFF
--- a/content/blog/2025-12-15-partner-insights-agentcore-overview.md
+++ b/content/blog/2025-12-15-partner-insights-agentcore-overview.md
@@ -1,5 +1,5 @@
 ---
-title: The AgentCore Ecosystem: Runtime, Identity, Gateway, Memory, and Observability
+title: "The AgentCore Ecosystem: Runtime, Identity, Gateway, Memory, and Observability"
 date: 2025-12-15
 author: Yoonsoo Park
 series: AWS re:Invent 2025


### PR DESCRIPTION
## Problem

prod build (`ENV=prod make deploy` -> `hugo --gc --minify`) failed:

```
ERROR error building site: ... 2025-12-15-partner-insights-agentcore-overview.md:2:8 ...
mapping value is not allowed in this context
title: The AgentCore Ecosystem: Runtime, Identity, ...
```

The `title:` value contains a colon (`Ecosystem:`) but wasn't quoted, so the YAML parser read it as a nested mapping key and aborted the build. Introduced during the series-suffix cleanup batch.

## Fix

Wrapped the title in double quotes.

## Files

- `content/blog/2025-12-15-partner-insights-agentcore-overview.md`

## Validation

`python3 scripts/validate_frontmatter.py` -> PASSED (194 posts).
