### PR TITLE
blog: two AWS agent-infra articles (Lambda MicroVMs + WAF for AgentCore Gateway) (en/ko)

### DIFF
--- a/content/blog/2026-07-02-waf-for-agentcore-gateway.en.md
+++ b/content/blog/2026-07-02-waf-for-agentcore-gateway.en.md
@@ -1,0 +1,64 @@
+---
+title: "WAF Comes to AgentCore Gateway: Perimeter Security for the MCP Front Door"
+date: 2026-07-02T09:05:00-04:00
+author: Yoonsoo Park
+description: "AWS WAF now protects Amazon Bedrock AgentCore Gateway. One Gateway-level config covers every downstream tool, agent, and integration. Here's why the MCP gateway is the right place to put the perimeter, and how to decide which rules to actually turn on."
+categories:
+  - AWS
+tags:
+  - waf
+  - agentcore
+  - security
+  - mcp
+  - bedrock
+---
+
+If you expose an agent to the outside world, the scary part isn't the model. It's the front door. The gateway that fans a single request out to a dozen MCP tools, a memory store, and downstream integrations is the highest-leverage thing an attacker can hit. One malformed or abusive request there touches everything behind it.
+
+In June 2026 AWS made [AWS WAF generally available for Amazon Bedrock AgentCore Gateway](https://aws-news.com/article/2026-06-29-aws-waf-adds-support-for-amazon-bedrock-agentcore-gateway). This is a small announcement with an outsized architectural implication: the perimeter for agentic workloads now sits at the gateway, where it belongs.
+
+## Why the gateway is the right control point
+
+AgentCore Gateway is the MCP front door. A caller hits the gateway, and the gateway routes to whatever tools, agents, and integrations sit behind it. That fan-out is exactly why it's the correct place to enforce protection:
+
+- **One config, everything covered.** A single Gateway-level WAF association protects all downstream tools and integrations at once. You don't bolt WAF onto each tool.
+- **It's where abuse concentrates.** Rate abuse, bot traffic, and known-bad payloads all funnel through the same entry point. Defend the funnel, not each cup.
+- **It's the trust boundary.** Everything upstream of the gateway is untrusted; everything downstream you built. That's the definition of a perimeter.
+
+Before this, securing that boundary meant custom infrastructure in front of the gateway. Now it's a managed association.
+
+## What you actually get to turn on
+
+The announcement lists concrete capabilities. Mapped to what they defend against:
+
+| Control | What it stops |
+|---------|---------------|
+| IP-based access controls | Callers from where you don't do business |
+| Rate-based rules | A single client hammering the gateway (cost + DoS) |
+| Managed Rule Group: Bot Control | Automated scraping and abuse traffic |
+| Managed Rule Group: Known Bad Inputs | Payloads matching published exploit signatures |
+| WAF protection packs | A curated bundle applied consistently |
+
+Available in every region where both WAF and AgentCore Gateway are supported, so unlike some launches this isn't gated to a handful of regions.
+
+## The decision tree: which rules, when
+
+Turning everything on is not the goal. Each rule has a false-positive cost, and agent traffic is weirder than normal web traffic. Here's how I'd sequence it.
+
+1. **Rate-based rules first, always.** The cheapest, highest-value control. An agent gateway with no rate limit is a cost incident waiting to happen, before you even get to security. Set a ceiling that's generous for real clients and lethal for a runaway loop.
+2. **IP controls if your caller set is knowable.** Internal or partner-only gateway? Allowlist the org's ranges. Public gateway? Skip the allowlist, it'll just cause pages.
+3. **Known Bad Inputs, in count mode first.** Turn it on counting, not blocking, watch for a week. Agent payloads (big JSON, tool schemas, embedded code) can trip signatures written for web forms. Promote to block only after you've confirmed the false-positive rate.
+4. **Bot Control last, and carefully.** Legitimate agent-to-agent (A2A) traffic can look exactly like a bot, because it is one. If your gateway serves other agents, Bot Control can shoot your own callers. Scope it or leave it off.
+
+The theme: the more an agent gateway is used by other machines, the more the "block bots" instinct works against you. Web WAF assumes humans are good and bots are bad. Agent WAF can't.
+
+## Pitfalls
+
+- **WAF is perimeter, not authorization.** It blocks abusive traffic shapes. It does not decide whether an authenticated caller is allowed to invoke a specific tool. You still need real authz at the gateway (scoped roles, OAuth, tool-level permissions). WAF in front, authz inside.
+- **Count mode before block mode, every managed rule.** The single most common WAF self-inflicted outage is enabling a managed group in block mode and discovering it eats legitimate traffic. Agent payloads make this worse. Count, observe, then block.
+- **Rate limits need a per-client key, not just per-IP.** Many agents call through NAT or a shared egress, so per-IP rate limiting can lump distinct tenants together. If you can key on an auth identity, do it.
+- **Don't let WAF become your only layer.** A gateway WAF is one ring. The downstream tools still need input validation and least privilege. Perimeter security that assumes the inside is safe is how one bypass becomes total.
+
+## What to do
+
+If you run an AgentCore Gateway that anything outside your own account can reach, associate a WAF, and start with a rate-based rule today. That one control alone closes the most likely incident (a runaway or abusive client). Then walk the rest of the tree in count mode. And keep the framing straight: WAF secures the shape of traffic hitting the front door. It is not a substitute for deciding, inside the gateway, who's allowed to open which door.

--- a/content/blog/2026-07-02-waf-for-agentcore-gateway.ko.md
+++ b/content/blog/2026-07-02-waf-for-agentcore-gateway.ko.md
@@ -1,0 +1,67 @@
+---
+title: "AgentCore Gateway에 WAF가 붙었다: MCP 정문에 방벽 세우기"
+date: 2026-07-02T09:05:00-04:00
+author: Yoonsoo Park
+description: "AWS WAF가 이제 Amazon Bedrock AgentCore Gateway를 보호한다. Gateway 레벨 설정 하나로 downstream tool, agent, integration 전부 커버된다. 왜 MCP gateway가 방벽을 세울 정확한 자리인지, 그리고 어떤 rule을 실제로 켜야 하는지 정리한다."
+categories:
+  - AWS
+tags:
+  - waf
+  - agentcore
+  - security
+  - mcp
+  - bedrock
+---
+
+Agent를 바깥에 노출하면, 무서운 건 모델이 아니다. 정문이다. 요청 하나를 수십 개 MCP tool, memory store, downstream integration으로 펼쳐주는 gateway가 공격자가 칠 수 있는 가장 레버리지 큰 지점이다. 거기서 잘못됐거나 악의적인 요청 하나가 뒤에 있는 전부에 닿는다.
+
+2026년 6월, AWS가 [Amazon Bedrock AgentCore Gateway용 AWS WAF를 GA](https://aws-news.com/article/2026-06-29-aws-waf-adds-support-for-amazon-bedrock-agentcore-gateway)로 냈다. 작은 발표인데 아키텍처적 함의는 크다. agentic 워크로드의 방벽이 이제 있어야 할 자리인 gateway에 놓인다.
+
+## 왜 gateway가 맞는 통제 지점인가
+
+AgentCore Gateway는 MCP 정문이다. caller가 gateway를 치면, gateway가 뒤에 있는 tool·agent·integration으로 라우팅한다. 이 fan-out이 바로 여기가 보호를 강제할 정확한 자리인 이유다.
+
+- **설정 하나로 전부 커버.** Gateway 레벨 WAF association 하나가 downstream tool·integration 전부를 한 번에 보호한다. tool마다 WAF를 붙일 필요 없다.
+- **abuse가 몰리는 지점이다.** rate abuse, bot 트래픽, known-bad payload가 전부 같은 진입점으로 깔때기처럼 모인다. 컵마다 지키지 말고 깔때기를 지켜라.
+- **trust boundary다.** gateway 상류는 전부 신뢰 안 됨, 하류는 내가 만든 것. 그게 방벽의 정의다.
+
+이전엔 이 경계를 지키려면 gateway 앞에 커스텀 인프라를 세워야 했다. 이제는 관리형 association이다.
+
+## 실제로 켤 수 있는 것
+
+발표문이 나열한 구체적 기능. 각각 뭘 막는지로 매핑하면.
+
+```
+통제                              막는 것
+──────────────────────────────────────────────────────────
+IP 기반 접근 통제                 거래 안 하는 지역의 caller
+Rate 기반 rule                    한 클라이언트가 gateway를 두들김 (비용+DoS)
+Managed Rule Group: Bot Control   자동 스크래핑·abuse 트래픽
+Managed Rule Group: Known Bad     공개된 exploit 시그니처에 맞는 payload
+Inputs
+WAF protection packs              큐레이션된 번들을 일관되게 적용
+```
+
+WAF와 AgentCore Gateway 둘 다 지원되는 모든 리전에서 쓸 수 있어서, 일부 런칭과 달리 몇 개 리전에만 묶여 있지 않다.
+
+## 결정 트리: 어떤 rule을, 언제
+
+다 켜는 게 목표가 아니다. rule마다 false-positive 비용이 있고, agent 트래픽은 일반 웹 트래픽보다 훨씬 이상하다. 나라면 이 순서로 간다.
+
+1. **Rate 기반 rule 먼저, 무조건.** 제일 싸고 가치 큰 통제. rate limit 없는 agent gateway는 보안 이전에 이미 터질 비용 사고다. 진짜 클라이언트한텐 넉넉하고 폭주 루프한텐 치명적인 상한을 잡아라.
+2. **caller 집합을 알 수 있으면 IP 통제.** 내부·파트너 전용 gateway면 org 대역을 allowlist. public gateway면 allowlist 건너뛰어라, 페이지 알림만 울린다.
+3. **Known Bad Inputs, 먼저 count 모드로.** block 말고 count로 켜고 일주일 지켜봐라. agent payload(큰 JSON, tool schema, embedded code)는 웹 폼용으로 짠 시그니처를 건드릴 수 있다. false-positive 비율 확인한 뒤에만 block으로 승격.
+4. **Bot Control 마지막에, 조심해서.** 정상적인 agent-to-agent(A2A) 트래픽은 bot처럼 보일 수 있다, 실제로 bot이니까. gateway가 다른 agent를 서비스하면 Bot Control이 내 caller를 쏠 수 있다. scope를 좁히거나 꺼둬라.
+
+주제는 이거다. agent gateway가 다른 기계에 많이 쓰일수록 "bot 막아" 본능이 나한테 불리하게 작동한다. 웹 WAF는 사람은 좋고 bot은 나쁘다고 가정한다. Agent WAF는 그럴 수 없다.
+
+## 함정
+
+- **WAF는 방벽이지 authorization이 아니다.** abusive한 트래픽 형태를 막는다. 인증된 caller가 특정 tool을 호출할 자격이 있는지는 안 정한다. gateway에 진짜 authz(scoped role, OAuth, tool 레벨 권한)는 여전히 필요하다. WAF는 앞에, authz는 안에.
+- **모든 managed rule은 block 전에 count 모드.** WAF 자해 장애 1순위가 managed group을 block 모드로 켜놓고 정상 트래픽을 잡아먹는 걸 발견하는 거다. agent payload가 이걸 더 악화시킨다. count, 관찰, 그다음 block.
+- **rate limit은 IP당이 아니라 클라이언트당 키가 필요하다.** 많은 agent가 NAT나 공유 egress로 호출해서, IP당 rate limiting은 서로 다른 tenant를 한 덩어리로 묶을 수 있다. auth identity로 키를 잡을 수 있으면 그렇게 해라.
+- **WAF를 유일한 레이어로 만들지 마라.** gateway WAF는 링 하나다. downstream tool은 여전히 입력 검증과 least privilege가 필요하다. 안쪽이 안전하다고 가정하는 방벽 보안이, bypass 하나가 전부가 되는 경로다.
+
+## 뭘 해야 하나
+
+내 계정 바깥 뭔가가 닿을 수 있는 AgentCore Gateway를 돌린다면, WAF를 붙이고 오늘 rate 기반 rule부터 시작해라. 그 통제 하나만으로도 가장 가능성 높은 사고(폭주하거나 abusive한 클라이언트)를 막는다. 나머지는 count 모드로 트리를 걸어가라. 그리고 프레이밍을 똑바로 유지해라. WAF는 정문에 닿는 트래픽의 *형태*를 지킨다. gateway 안에서 누가 어느 문을 열 수 있는지 정하는 걸 대신해주진 않는다.

--- a/content/blog/2026-07-02-waf-for-agentcore-gateway.ko.md
+++ b/content/blog/2026-07-02-waf-for-agentcore-gateway.ko.md
@@ -13,55 +13,55 @@ tags:
   - bedrock
 ---
 
-Agent를 바깥에 노출하면, 무서운 건 모델이 아니다. 정문이다. 요청 하나를 수십 개 MCP tool, memory store, downstream integration으로 펼쳐주는 gateway가 공격자가 칠 수 있는 가장 레버리지 큰 지점이다. 거기서 잘못됐거나 악의적인 요청 하나가 뒤에 있는 전부에 닿는다.
+Agent를 바깥에 노출할 때 무서운 건 모델이 아니다. 정문이다. 요청 하나를 수십 개의 MCP tool과 memory store, downstream integration으로 펼쳐주는 gateway야말로 공격자 입장에서 레버리지가 가장 큰 지점이다. 여기서 잘못된 요청이나 악의적인 요청 하나가 뒤에 있는 모든 곳에 침투 가능하다.
 
-2026년 6월, AWS가 [Amazon Bedrock AgentCore Gateway용 AWS WAF를 GA](https://aws-news.com/article/2026-06-29-aws-waf-adds-support-for-amazon-bedrock-agentcore-gateway)로 냈다. 작은 발표인데 아키텍처적 함의는 크다. agentic 워크로드의 방벽이 이제 있어야 할 자리인 gateway에 놓인다.
+2026년 6월, AWS가 [Amazon Bedrock AgentCore Gateway용 AWS WAF를 GA](https://aws-news.com/article/2026-06-29-aws-waf-adds-support-for-amazon-bedrock-agentcore-gateway)로 출시했다. 작은 발표지만 아키텍처적 존재감은 크다. agentic 워크로드의 방벽이 이제 원래 있어야 할 자리(gateway)에 놓이게 됐다.
 
 ## 왜 gateway가 맞는 통제 지점인가
 
-AgentCore Gateway는 MCP 정문이다. caller가 gateway를 치면, gateway가 뒤에 있는 tool·agent·integration으로 라우팅한다. 이 fan-out이 바로 여기가 보호를 강제할 정확한 자리인 이유다.
+AgentCore Gateway는 MCP의 정문이다. caller가 gateway를 치면, gateway가 뒤에 있는 tool·agent·integration으로 요청을 라우팅한다. 바로 이 fan-out 때문에 gateway가 보호하기 정확하게 좋은 자리가 된다.
 
-- **설정 하나로 전부 커버.** Gateway 레벨 WAF association 하나가 downstream tool·integration 전부를 한 번에 보호한다. tool마다 WAF를 붙일 필요 없다.
-- **abuse가 몰리는 지점이다.** rate abuse, bot 트래픽, known-bad payload가 전부 같은 진입점으로 깔때기처럼 모인다. 컵마다 지키지 말고 깔때기를 지켜라.
-- **trust boundary다.** gateway 상류는 전부 신뢰 안 됨, 하류는 내가 만든 것. 그게 방벽의 정의다.
+- **설정 하나로 전부 커버한다.** gateway 레벨에서 WAF를 한 번 연결하면 downstream tool과 integration이 한꺼번에 보호된다. tool마다 WAF를 붙일 필요가 없다.
+- **abuse가 몰리는 지점이다.** rate abuse, bot 트래픽, known-bad payload가 전부 같은 진입점으로 모인다. 뒤에 component 하나하나 지키지 말고 대문을 지켜라.
+- **trust boundary다.** gateway 바깥은 전부 신뢰할 수 없고, 그 안에 내가 만든 서비스들.
 
-이전엔 이 경계를 지키려면 gateway 앞에 커스텀 인프라를 세워야 했다. 이제는 관리형 association이다.
+예전엔 이 경계를 지키려면 gateway 앞에 커스텀 인프라가 필요했다. 근데 이제는 관리형 연결(association) 하나면 된다.
 
 ## 실제로 켤 수 있는 것
 
-발표문이 나열한 구체적 기능. 각각 뭘 막는지로 매핑하면.
+발표문이 나열한 구체적인 기능을, 각각 무엇을 막는지로 매핑하면 이렇다.
 
 ```
 통제                              막는 것
 ──────────────────────────────────────────────────────────
-IP 기반 접근 통제                 거래 안 하는 지역의 caller
-Rate 기반 rule                    한 클라이언트가 gateway를 두들김 (비용+DoS)
+IP 기반 접근 통제                 거래하지 않는 지역의 caller
+Rate 기반 rule                    한 클라이언트가 gateway를 두들기는 것 (비용+DoS)
 Managed Rule Group: Bot Control   자동 스크래핑·abuse 트래픽
 Managed Rule Group: Known Bad     공개된 exploit 시그니처에 맞는 payload
 Inputs
 WAF protection packs              큐레이션된 번들을 일관되게 적용
 ```
 
-WAF와 AgentCore Gateway 둘 다 지원되는 모든 리전에서 쓸 수 있어서, 일부 런칭과 달리 몇 개 리전에만 묶여 있지 않다.
+WAF와 AgentCore Gateway가 둘 다 지원되는 모든 리전에서 쓸 수 있다. 일부 런칭과 달리 몇몇 리전에만 묶여 있지 않다.
 
 ## 결정 트리: 어떤 rule을, 언제
 
-다 켜는 게 목표가 아니다. rule마다 false-positive 비용이 있고, agent 트래픽은 일반 웹 트래픽보다 훨씬 이상하다. 나라면 이 순서로 간다.
+다 켜는 게 목표가 아니다. rule마다 false-positive 비용이 있고, agent 트래픽은 일반 웹 트래픽보다 훨씬 복잡하다. 나라면 이 순서로 간다.
 
-1. **Rate 기반 rule 먼저, 무조건.** 제일 싸고 가치 큰 통제. rate limit 없는 agent gateway는 보안 이전에 이미 터질 비용 사고다. 진짜 클라이언트한텐 넉넉하고 폭주 루프한텐 치명적인 상한을 잡아라.
-2. **caller 집합을 알 수 있으면 IP 통제.** 내부·파트너 전용 gateway면 org 대역을 allowlist. public gateway면 allowlist 건너뛰어라, 페이지 알림만 울린다.
-3. **Known Bad Inputs, 먼저 count 모드로.** block 말고 count로 켜고 일주일 지켜봐라. agent payload(큰 JSON, tool schema, embedded code)는 웹 폼용으로 짠 시그니처를 건드릴 수 있다. false-positive 비율 확인한 뒤에만 block으로 승격.
-4. **Bot Control 마지막에, 조심해서.** 정상적인 agent-to-agent(A2A) 트래픽은 bot처럼 보일 수 있다, 실제로 bot이니까. gateway가 다른 agent를 서비스하면 Bot Control이 내 caller를 쏠 수 있다. scope를 좁히거나 꺼둬라.
+1. **Rate 기반 rule부터, 무조건.** 제일 싸고 가치가 큰 통제다. rate limit 없는 agent gateway는 보안 문제 이전에 비용 사고가 터질 수 있다. 진짜 클라이언트한테는 넉넉하되, bad actor를 대비해서 상한을 잡아라.
+2. **caller 집합을 알 수 있으면 IP 통제.** 내부·파트너 전용 gateway라면 org 대역을 allowlist로 잡아라. public gateway라면 allowlist는 필요 없음.
+3. **Known Bad Inputs는 먼저 count 모드로.** block이 아니라 count로 켜고 일주일 지켜봐라. agent payload(큰 JSON, tool schema, embedded code)는 웹 폼용으로 만든 시그니처를 건드릴 수 있다. false-positive 비율을 확인한 뒤에만 block으로 promotion하기.
+4. **Bot Control은 마지막에, 조심해서.** 정상적인 agent-to-agent(A2A) 트래픽은 bot처럼 보일 수 있다. 실제로 bot이니까. gateway가 다른 agent를 서비스한다면 Bot Control이 내 caller를 쏠 수 있다. scope를 좁히거나 아예 꺼둬라.
 
-주제는 이거다. agent gateway가 다른 기계에 많이 쓰일수록 "bot 막아" 본능이 나한테 불리하게 작동한다. 웹 WAF는 사람은 좋고 bot은 나쁘다고 가정한다. Agent WAF는 그럴 수 없다.
+여기서 공통적으로 나오는 내용이 있다. agent gateway가 사람보다 다른 machine에서 많이 쓰일수록, "bot을 막아라"라는 것에 단점이 장점보다 커지기 시작한다. 웹 WAF는 사람은 좋고 bot은 나쁘다고 가정한다. Agent WAF는 그렇게 가정할 수 없다.
 
-## 함정
+## 생각해볼것
 
-- **WAF는 방벽이지 authorization이 아니다.** abusive한 트래픽 형태를 막는다. 인증된 caller가 특정 tool을 호출할 자격이 있는지는 안 정한다. gateway에 진짜 authz(scoped role, OAuth, tool 레벨 권한)는 여전히 필요하다. WAF는 앞에, authz는 안에.
-- **모든 managed rule은 block 전에 count 모드.** WAF 자해 장애 1순위가 managed group을 block 모드로 켜놓고 정상 트래픽을 잡아먹는 걸 발견하는 거다. agent payload가 이걸 더 악화시킨다. count, 관찰, 그다음 block.
-- **rate limit은 IP당이 아니라 클라이언트당 키가 필요하다.** 많은 agent가 NAT나 공유 egress로 호출해서, IP당 rate limiting은 서로 다른 tenant를 한 덩어리로 묶을 수 있다. auth identity로 키를 잡을 수 있으면 그렇게 해라.
-- **WAF를 유일한 레이어로 만들지 마라.** gateway WAF는 링 하나다. downstream tool은 여전히 입력 검증과 least privilege가 필요하다. 안쪽이 안전하다고 가정하는 방벽 보안이, bypass 하나가 전부가 되는 경로다.
+- **WAF는 방벽이지 authorization이 아니다.** abusive한 트래픽의 형태는 막지만, 인증된 caller가 특정 tool을 호출할 자격이 있는지는 정하지 않는다. gateway에는 진짜 authz(scoped role, OAuth, tool 레벨 권한)가 여전히 필요하다. WAF는 앞에, authz는 안에.
+- **모든 managed rule은 block 전에 count 모드로.** WAF에서 가장 흔한 자책성 장애는, managed group을 block 모드로 켜놓고 이후에 정상 트래픽을 잡아먹고 있었다는 걸 발견하는 것이다. agent payload는 이걸 더 악화시킨다. count하고, 관찰하고, 그다음 block해라.
+- **rate limit은 IP당이 아니라 클라이언트당으로 키를 잡아야 한다.** 많은 agent가 NAT나 공유 egress를 거쳐 호출하기 때문에, IP당 rate limiting은 서로 다른 tenant를 한 덩어리로 묶어버릴 수 있다. auth identity로 키를 잡을 수 있다면 적용하는게 좋다.
+- **WAF를 유일한 레이어로 두지 마라.** gateway WAF는 여러 겹 중 하나일 뿐이다. downstream tool에는 여전히 입력 검증과 least privilege가 절대적으로 필요하다. 안쪽은 안전하다고 가정하는 방벽 보안은, bypass 하나가 곧 전부를 뚫는 경로가 된다.
 
 ## 뭘 해야 하나
 
-내 계정 바깥 뭔가가 닿을 수 있는 AgentCore Gateway를 돌린다면, WAF를 붙이고 오늘 rate 기반 rule부터 시작해라. 그 통제 하나만으로도 가장 가능성 높은 사고(폭주하거나 abusive한 클라이언트)를 막는다. 나머지는 count 모드로 트리를 걸어가라. 그리고 프레이밍을 똑바로 유지해라. WAF는 정문에 닿는 트래픽의 *형태*를 지킨다. gateway 안에서 누가 어느 문을 열 수 있는지 정하는 걸 대신해주진 않는다.
+내 계정 바깥에서 닿을 수 있는 곳에 AgentCore Gateway를 운영 중이라면, WAF를 붙이고 오늘 바로 rate 기반 rule부터 시작하길 추천한다. 그 통제 하나만으로도 가장 일어나기 쉬운 사고, 즉 폭주하거나 abusive한 클라이언트를 막을 수 있다. 나머지는 count 모드로 결정 트리를 이용해서 결정. 명심할 점은 WAF 하나 붙였다고 gateway 보안이 끝났다고 착각하면 안됨. WAF는 문지기일 뿐, 내부 권한 통제(authz)는 여전히 우리의 몫.

--- a/content/blog/2026-07-02-where-to-run-agent-generated-code.en.md
+++ b/content/blog/2026-07-02-where-to-run-agent-generated-code.en.md
@@ -1,0 +1,65 @@
+---
+title: "Where Do You Run Agent-Generated Code? Lambda MicroVMs and the Isolation Tradeoff"
+date: 2026-07-02T09:00:00-04:00
+author: Yoonsoo Park
+description: "AWS Lambda MicroVMs give you Firecracker VM-level isolation with suspend/resume for up to 8 hours. Here's the real decision: when you actually need this versus a Code Interpreter sandbox versus a plain container, and the pitfalls of running code your agent wrote."
+categories:
+  - AWS
+tags:
+  - lambda
+  - firecracker
+  - agentcore
+  - security
+  - agents
+---
+
+If you build agents, you eventually hit the question nobody wants: the model just wrote some code, and now something has to run it. Not your code. Code the LLM generated a second ago, possibly wrong, possibly hostile if a prompt injection got through. Where does that run?
+
+In June 2026 AWS shipped [Lambda MicroVMs](https://aws-news.com/article/2026-06-22-aws-introduces-lambda-microvms-for-isolated-execution-of-user-and-ai-generated-code), a compute primitive built for exactly this. It is worth understanding not because it is new and shiny, but because it forces you to be honest about a tradeoff you were probably ignoring.
+
+## The three things you want and can't all have
+
+When you run untrusted code, you want three properties at once:
+
+1. **Isolation** so a bad process can't read another tenant's data or escape into your infra.
+2. **Speed** so the agent doesn't stall for seconds every time it runs a snippet.
+3. **State** so a long task can pause, keep its working directory and memory, and resume later.
+
+Historically you picked two. A shared container is fast and stateful but the isolation is a namespace, not a wall. A fresh Firecracker microVM per request is isolated and fast to boot but throws away all state. A full EC2 VM is isolated and stateful but nowhere near instant.
+
+Lambda MicroVMs are AWS's claim that you can now have all three. It's the same Firecracker tech underneath Lambda (the announcement cites 15+ trillion invocations a month), but exposed as a primitive you launch directly.
+
+## What it actually gives you
+
+The concrete capabilities, stripped of marketing:
+
+- **VM-level isolation** for multi-tenant execution, without you managing any virtualization layer.
+- **Near-instant launch**, plus suspend and resume for **up to 8 hours**. This is the interesting part. A microVM can hold a paused task, and you resume it later instead of rebuilding context.
+- **Images from a Dockerfile**, launched with a dedicated **HTTPS URL** that speaks HTTP/2, gRPC, and WebSockets.
+- **Pay for baseline while running**, plus whatever you consume above baseline.
+
+The suspend/resume window is what separates this from "just a fast sandbox." An agent that runs a multi-step task, waits on a human approval, then continues, can now sit in a suspended microVM instead of holding a container open or serializing its whole state to disk and rehydrating.
+
+## The decision: do you actually need this?
+
+This is the part that matters. Reaching for microVM isolation when a lighter option would do is over-engineering. Here's how I'd decide.
+
+| Situation | What to reach for |
+|-----------|-------------------|
+| Agent runs short, pure-compute snippets you generated and control | A managed Code Interpreter sandbox. Don't build infra. |
+| Untrusted / model-generated code, multi-tenant, needs network or filesystem | Lambda MicroVMs. This is the case they built it for. |
+| Long task that pauses on human approval then resumes | Lambda MicroVMs, for the suspend/resume window. |
+| Trusted code, your own logic, just needs to scale | Plain Lambda or a container. Isolation is already fine. |
+
+The signal that you need real VM isolation is not "I'm running code." It's "I'm running code I did not write, on behalf of tenants who don't trust each other." If that sentence isn't true, a managed sandbox is cheaper and simpler.
+
+## Pitfalls I'd watch for
+
+- **Isolation is not a license to skip input handling.** VM-level isolation stops an escape. It does not stop the agent from cheerfully running `rm -rf` on the data volume you mounted, or exfiltrating a secret you passed in as an env var. Isolation contains blast radius; it doesn't decide what's inside the blast.
+- **The 8-hour resume window is a cost trap if you forget about it.** A suspended microVM still bills baseline compute. An agent that suspends tasks and never cleans them up is a slow leak. Track and reap suspended VMs like you'd track idle connections.
+- **Regional availability is narrow at launch.** N. Virginia, Ohio, Oregon, Tokyo, Ireland. If your agents run elsewhere, this isn't an option yet, and designing around it now means a migration later.
+- **HTTPS-URL-per-microVM changes your network model.** Each VM gets its own endpoint. That's convenient, but it's also a lot of ephemeral surface. Front it, log it, and don't let those URLs leak into agent-visible context where a prompt injection could target them.
+
+## What to do
+
+If you run agents that execute code they generated, write down which of the four rows above you're actually in. Most teams are in row 1 or row 4 and don't need a microVM. The teams that genuinely need it, multi-tenant execution of untrusted code with pause/resume, now have a primitive built for the job instead of a pile of Firecracker glue. Pick based on the isolation you actually need, not the isolation that sounds safest.

--- a/content/blog/2026-07-02-where-to-run-agent-generated-code.ko.md
+++ b/content/blog/2026-07-02-where-to-run-agent-generated-code.ko.md
@@ -2,7 +2,7 @@
 title: "Agent가 만든 코드, 어디서 돌릴 건데? Lambda MicroVMs와 격리의 트레이드오프"
 date: 2026-07-02T09:00:00-04:00
 author: Yoonsoo Park
-description: "AWS Lambda MicroVMs는 Firecracker 기반 VM 수준 격리에 최대 8시간 suspend/resume까지 준다. 진짜 질문은 이거다. 언제 이게 필요하고 언제 Code Interpreter 샌드박스나 그냥 컨테이너면 충분한가. 그리고 agent가 짠 코드를 돌릴 때의 함정들."
+description: "AWS Lambda MicroVMs는 Firecracker 기반 VM 수준 격리에 최대 8시간 suspend/resume까지 준다. 그럼 언제 이게 필요하고 언제 Code Interpreter 샌드박스나 그냥 컨테이너면 충분한가. 그리고 agent가 짠 코드를 돌릴 때의 가능한 문제점."
 categories:
   - AWS
 tags:
@@ -13,41 +13,39 @@ tags:
   - agents
 ---
 
-Agent를 만들다 보면 아무도 반기지 않는 질문에 결국 부딪힌다. 모델이 방금 코드를 짰고, 이제 뭔가가 그걸 실행해야 한다. 내 코드가 아니다. LLM이 1초 전에 생성한 코드고, 틀렸을 수도 있고, prompt injection이 뚫렸으면 악의적일 수도 있다. 그걸 어디서 돌릴 건데?
+Agent를 만들다 보면 모델이 방금 생성한 코드를 실행하고 싶을때가 있다. 근데 LLM이 방금 생성한 코드는 틀렸을 수도 있고, prompt injection이 뚫렸으면 위험할 수도 있다. 그걸 어디서 돌릴건지 생각해야된다.
 
-2026년 6월, AWS가 [Lambda MicroVMs](https://aws-news.com/article/2026-06-22-aws-introduces-lambda-microvms-for-isolated-execution-of-user-and-ai-generated-code)를 냈다. 딱 이 문제를 위한 compute primitive다. 새거고 반짝여서가 아니라, 그동안 대충 눈감고 있던 트레이드오프를 정면으로 마주보게 만들어서 알아둘 가치가 있다.
+2026년 6월, AWS가 [Lambda MicroVMs](https://aws-news.com/article/2026-06-22-aws-introduces-lambda-microvms-for-isolated-execution-of-user-and-ai-generated-code)를 발표했다. 딱 이 문제를 위한 compute primitive 솔류션이다. 그동안 대충 괜찮겠지 뭐... 했던 리스크를 표면으로 끌어올리는 것이라 알아둘만하다.
 
 ## 원하는 세 가지, 다 가질 순 없다
 
-신뢰 안 되는 코드를 돌릴 때 동시에 원하는 속성이 셋 있다.
+신뢰 안 되는 코드를 돌릴 때 동시에 갖고 싶은 세가지.
 
-1. **격리(isolation)**. 나쁜 프로세스가 다른 tenant 데이터를 읽거나 내 인프라로 탈출하지 못하게.
-2. **속도(speed)**. 스니펫 하나 돌릴 때마다 agent가 몇 초씩 멈추지 않게.
-3. **상태(state)**. 긴 작업이 멈췄다가 working directory와 메모리를 그대로 들고 나중에 재개할 수 있게.
+1. **격리(isolation)**. 나쁜 프로세스가 다른 tenant 데이터를 조회 및 내 인프라로 탈출하지 못하게.
+2. **속도(speed)**. snippet 하나 돌릴 때마다 agent가 몇 초씩 멈추면 뭔 소용.
+3. **상태(state)**. 긴 작업이 멈췄다가 working directory와 메모리를 유지해서 나중에 계속 진행 가능한 경험.
 
-원래는 이 중 둘만 골랐다. 공유 컨테이너는 빠르고 상태도 유지되지만 격리가 벽이 아니라 namespace다. 요청마다 새로 뜨는 Firecracker microVM은 격리되고 부팅도 빠르지만 상태를 다 버린다. 풀 EC2 VM은 격리·상태 다 되지만 즉각적이지 않다.
+이전에는 이 중 둘만 고를 수 있었다. 공유 컨테이너는 빠르고 상태도 유지되지만 격리가 벽이라기 보단 soft isolation, 즉 namespace다. 요청마다 새로 뜨는 Firecracker microVM은 격리되고 부팅도 빠르지만 이전 상태를 유지 못함. 풀 EC2 VM은 격리·상태 다 되지만 느림.
 
-Lambda MicroVMs는 이제 셋 다 가질 수 있다는 AWS의 주장이다. 밑바닥은 Lambda를 떠받치는 그 Firecracker(발표문 기준 월 15조+ 호출)고, 이걸 직접 띄우는 primitive로 노출한 거다.
+AWS는 Lambda MicroVMs는 이제 셋 다 가질 수 있다고 주장한다. Lambda 밑에서 돌아가는 것과 똑같은 Firecracker 기술인데(발표문은 월 15조 건 이상의 호출을 근거로 든다), 이번엔 직접 띄울 수 있는 primitive로 노출됐다.
 
-## 실제로 주는 것
+## 실제로 기능들
 
-마케팅 걷어낸 실제 기능.
-
-- **VM 수준 격리**. multi-tenant 실행인데 virtualization layer를 내가 관리 안 해도 됨.
-- **거의 즉각 launch**, 거기에 **최대 8시간** suspend/resume. 이게 재밌는 부분이다. microVM이 멈춘 작업을 붙잡고 있다가, context를 다시 쌓는 대신 나중에 그대로 재개한다.
+- **VM 수준 격리**. multi-tenant 실행이지만 내가 virtualization layer를 관리 안 해도 됨.
+- **거의 즉각 launch**, 거기에 **최대 8시간** suspend/resume. 이게 재밌고 비용면에서는 무서운 부분. microVM이 멈춘 작업을 유지하다가, 나중에 그대로 재개한다.
 - **Dockerfile로 이미지** 만들고, HTTP/2·gRPC·WebSocket 다 되는 **전용 HTTPS URL**로 launch.
-- **돌아가는 동안 baseline 과금**, baseline 초과분은 쓴 만큼.
+- **돌아가는 동안 baseline 과금**, baseline 초과분은 쓴 만큼 청구.
 
-suspend/resume 창이 "그냥 빠른 샌드박스"랑 이걸 가르는 지점이다. 여러 단계 작업을 돌리다가 사람 승인을 기다린 뒤 이어가는 agent가, 컨테이너를 열어두거나 전체 상태를 디스크에 직렬화했다 되살리는 대신, suspend된 microVM에 그냥 앉아 있으면 된다.
+suspend/resume 창이 "그냥 빠른 샌드박스"랑 가장 다른 점으로 보인다. 여러 단계 작업을 돌리다가 사람 승인을 기다린 뒤 이어가는 agent가, 컨테이너를 열어두거나 전체 상태를 디스크에 저장했다가 되살리는 대신, suspend된 microVM에서 그냥 대기하면 됨.
 
-## 결정: 진짜 이게 필요한가?
+## 결정: 이게 진짜 필요한가?
 
-여기가 핵심이다. 가벼운 옵션으로 충분한데 microVM 격리를 집어드는 건 오버엔지니어링이다. 나라면 이렇게 판단한다.
+물론 가벼운 옵션으로 충분한데 microVM 격리를 집어드는 건 오버엔지니어링이다. 판단 기준을 다음과 같다.
 
 ```
 상황                                          집어들 것
 ────────────────────────────────────────────────────────────
-내가 만들고 통제하는 짧은 순수 연산 스니펫     관리형 Code Interpreter 샌드박스.
+내가 만들고 통제하는 짧은 순수 연산 snippet     관리형 Code Interpreter 샌드박스.
                                               인프라 짓지 마라.
 신뢰 안 되는/모델 생성 코드, multi-tenant,     Lambda MicroVMs.
 네트워크나 파일시스템 필요                      이게 만들어진 이유.
@@ -56,15 +54,21 @@ suspend/resume 창이 "그냥 빠른 샌드박스"랑 이걸 가르는 지점이
                                               격리는 이미 충분.
 ```
 
-VM 격리가 진짜 필요하다는 신호는 "코드를 돌린다"가 아니다. "내가 안 쓴 코드를, 서로 신뢰 안 하는 tenant들을 위해 돌린다"이다. 이 문장이 참이 아니면 관리형 샌드박스가 더 싸고 단순하다.
+VM 격리가 진짜 필요하다는 시그널은 간단히 "내가 안 쓴 코드를 (리스크있는 코드), tenant isolation을 위해 돌린다"이다. 이외의 경우에는 관리형 샌드박스가 더 싸고 쉽다.
 
-## 지켜볼 함정들
+## 체크할 만한 문제점들
 
-- **격리가 입력 처리를 건너뛸 면허는 아니다.** VM 수준 격리는 탈출을 막는다. 근데 agent가 내가 마운트해준 데이터 볼륨에 신나게 `rm -rf`를 날리거나, env var로 넘긴 secret을 유출하는 건 못 막는다. 격리는 blast radius를 가둘 뿐, 그 안에서 뭐가 터질지는 안 정해준다.
-- **8시간 resume 창은 까먹으면 비용 함정이다.** suspend된 microVM도 baseline compute는 계속 과금된다. 작업을 suspend해놓고 안 치우는 agent는 느린 누수다. idle connection 관리하듯 suspend된 VM을 추적하고 회수해라.
-- **런칭 시점 리전이 좁다.** N. Virginia, Ohio, Oregon, Tokyo, Ireland. agent가 다른 데서 돌면 아직 옵션이 아니고, 지금 이걸 전제로 설계하면 나중에 마이그레이션이다.
-- **microVM마다 HTTPS URL은 네트워크 모델을 바꾼다.** VM마다 자기 endpoint를 갖는다. 편하긴 한데 ephemeral surface가 확 늘어난다는 뜻이기도 하다. 앞단에 뭘 두고, 로깅하고, 그 URL이 prompt injection이 노릴 수 있는 agent 가시 context로 새 나가지 않게 해라.
+- **격리가 입력 처리를 건너뛰어도 된다는건 아니다.** VM 수준 격리는 탈출을 막는다. 근데 agent가 내가 마운트해준 데이터 볼륨에 신나게 `rm -rf`를 날리거나, env var로 넘긴 secret을 유출하는 건 못 막는다. 격리는 blast radius를 가둘 뿐, 그 안에서 뭐가 터질지는 보장하지 못함.
+- **8시간 resume 창은 까먹으면 비용 함정이다.** suspend된 microVM도 baseline compute는 계속 과금된다. 작업을 suspend해놓고 agent를 정리 안했다면 각오해야될듯. idle connection 관리하듯 suspend된 VM을 추적하고 회수해라.
+- **런칭 시점 리전이 좁다.** N. Virginia, Ohio, Oregon, Tokyo, Ireland. agent가 다른 데서 돌면 아직 옵션 사항이 되지 못함.
+- **microVM마다 HTTPS URL은 네트워크 모델을 바꾼다.** VM마다 자기 endpoint를 갖는다. 편하긴 한데 ephemeral surface가 확 늘어난다는 뜻이기도 하다.
 
-## 뭘 해야 하나
+## 그래서요?
 
-코드 생성하는 agent를 돌린다면, 위 네 줄 중 실제로 어디에 있는지 적어둬라. 대부분의 팀은 1번이나 4번이고 microVM 필요 없다. 진짜 필요한 팀, 신뢰 안 되는 코드를 pause/resume 붙여 multi-tenant로 돌리는 팀은, 이제 Firecracker glue 더미 대신 이 일을 위해 만들어진 primitive가 생겼다. 제일 안전해 *보이는* 격리가 아니라, 실제로 필요한 격리를 기준으로 골라라.
+코드를 생성하는 agent를 돌린다면, 결정하기 전에 우리 use case가 실제로 어디에 속하는지 먼저 따져봐야 한다. 대부분의 경우엔 microVM까지 필요 없다.
+
+microVM이 진짜 필요한 팀은 따로 있다. 신뢰할 수 없는 코드를 실행하고, 거기에 pause/resume을 붙여 multi-tenant로 돌려야 하는 팀이다. 예전에 이런 팀은 Firecracker를 직접 다뤄야 했다. Firecracker는 microVM을 띄우는 저수준 엔진일 뿐이라, 실제 서비스로 돌리려면 그 위에 직접 얹어야 할 게 산더미였다. microVM lifecycle 관리, VM마다 네트워킹 설정, 루트 파일시스템 준비, 스냅샷 기반 pause/resume, multi-tenant 스케줄링까지 — 이 모든 orchestration 코드를 팀이 알아서 짜서 붙이고, 계속 유지보수해야 했다. 부품들을 억지로 이어붙인 접착제(glue) 같은 코드 더미였다.
+
+이제는 그럴 필요가 없다. 바로 이 일을 위해 만들어진 primitive가 생겼기 때문이다. 직접 Firecracker를 엮는 대신, 그 orchestration을 대신 해주는 빌딩블록을 그냥 가져다 쓰면 된다.
+
+핵심은 이거다. 제일 안전해 *보이는* 격리를 고르지 마라. 실제로 필요한 격리 수준을 기준으로 골라라.

--- a/content/blog/2026-07-02-where-to-run-agent-generated-code.ko.md
+++ b/content/blog/2026-07-02-where-to-run-agent-generated-code.ko.md
@@ -1,0 +1,70 @@
+---
+title: "Agent가 만든 코드, 어디서 돌릴 건데? Lambda MicroVMs와 격리의 트레이드오프"
+date: 2026-07-02T09:00:00-04:00
+author: Yoonsoo Park
+description: "AWS Lambda MicroVMs는 Firecracker 기반 VM 수준 격리에 최대 8시간 suspend/resume까지 준다. 진짜 질문은 이거다. 언제 이게 필요하고 언제 Code Interpreter 샌드박스나 그냥 컨테이너면 충분한가. 그리고 agent가 짠 코드를 돌릴 때의 함정들."
+categories:
+  - AWS
+tags:
+  - lambda
+  - firecracker
+  - agentcore
+  - security
+  - agents
+---
+
+Agent를 만들다 보면 아무도 반기지 않는 질문에 결국 부딪힌다. 모델이 방금 코드를 짰고, 이제 뭔가가 그걸 실행해야 한다. 내 코드가 아니다. LLM이 1초 전에 생성한 코드고, 틀렸을 수도 있고, prompt injection이 뚫렸으면 악의적일 수도 있다. 그걸 어디서 돌릴 건데?
+
+2026년 6월, AWS가 [Lambda MicroVMs](https://aws-news.com/article/2026-06-22-aws-introduces-lambda-microvms-for-isolated-execution-of-user-and-ai-generated-code)를 냈다. 딱 이 문제를 위한 compute primitive다. 새거고 반짝여서가 아니라, 그동안 대충 눈감고 있던 트레이드오프를 정면으로 마주보게 만들어서 알아둘 가치가 있다.
+
+## 원하는 세 가지, 다 가질 순 없다
+
+신뢰 안 되는 코드를 돌릴 때 동시에 원하는 속성이 셋 있다.
+
+1. **격리(isolation)**. 나쁜 프로세스가 다른 tenant 데이터를 읽거나 내 인프라로 탈출하지 못하게.
+2. **속도(speed)**. 스니펫 하나 돌릴 때마다 agent가 몇 초씩 멈추지 않게.
+3. **상태(state)**. 긴 작업이 멈췄다가 working directory와 메모리를 그대로 들고 나중에 재개할 수 있게.
+
+원래는 이 중 둘만 골랐다. 공유 컨테이너는 빠르고 상태도 유지되지만 격리가 벽이 아니라 namespace다. 요청마다 새로 뜨는 Firecracker microVM은 격리되고 부팅도 빠르지만 상태를 다 버린다. 풀 EC2 VM은 격리·상태 다 되지만 즉각적이지 않다.
+
+Lambda MicroVMs는 이제 셋 다 가질 수 있다는 AWS의 주장이다. 밑바닥은 Lambda를 떠받치는 그 Firecracker(발표문 기준 월 15조+ 호출)고, 이걸 직접 띄우는 primitive로 노출한 거다.
+
+## 실제로 주는 것
+
+마케팅 걷어낸 실제 기능.
+
+- **VM 수준 격리**. multi-tenant 실행인데 virtualization layer를 내가 관리 안 해도 됨.
+- **거의 즉각 launch**, 거기에 **최대 8시간** suspend/resume. 이게 재밌는 부분이다. microVM이 멈춘 작업을 붙잡고 있다가, context를 다시 쌓는 대신 나중에 그대로 재개한다.
+- **Dockerfile로 이미지** 만들고, HTTP/2·gRPC·WebSocket 다 되는 **전용 HTTPS URL**로 launch.
+- **돌아가는 동안 baseline 과금**, baseline 초과분은 쓴 만큼.
+
+suspend/resume 창이 "그냥 빠른 샌드박스"랑 이걸 가르는 지점이다. 여러 단계 작업을 돌리다가 사람 승인을 기다린 뒤 이어가는 agent가, 컨테이너를 열어두거나 전체 상태를 디스크에 직렬화했다 되살리는 대신, suspend된 microVM에 그냥 앉아 있으면 된다.
+
+## 결정: 진짜 이게 필요한가?
+
+여기가 핵심이다. 가벼운 옵션으로 충분한데 microVM 격리를 집어드는 건 오버엔지니어링이다. 나라면 이렇게 판단한다.
+
+```
+상황                                          집어들 것
+────────────────────────────────────────────────────────────
+내가 만들고 통제하는 짧은 순수 연산 스니펫     관리형 Code Interpreter 샌드박스.
+                                              인프라 짓지 마라.
+신뢰 안 되는/모델 생성 코드, multi-tenant,     Lambda MicroVMs.
+네트워크나 파일시스템 필요                      이게 만들어진 이유.
+사람 승인에서 멈췄다 재개하는 긴 작업          Lambda MicroVMs. suspend/resume 때문.
+내 로직, 신뢰되는 코드, 그냥 스케일만          그냥 Lambda나 컨테이너.
+                                              격리는 이미 충분.
+```
+
+VM 격리가 진짜 필요하다는 신호는 "코드를 돌린다"가 아니다. "내가 안 쓴 코드를, 서로 신뢰 안 하는 tenant들을 위해 돌린다"이다. 이 문장이 참이 아니면 관리형 샌드박스가 더 싸고 단순하다.
+
+## 지켜볼 함정들
+
+- **격리가 입력 처리를 건너뛸 면허는 아니다.** VM 수준 격리는 탈출을 막는다. 근데 agent가 내가 마운트해준 데이터 볼륨에 신나게 `rm -rf`를 날리거나, env var로 넘긴 secret을 유출하는 건 못 막는다. 격리는 blast radius를 가둘 뿐, 그 안에서 뭐가 터질지는 안 정해준다.
+- **8시간 resume 창은 까먹으면 비용 함정이다.** suspend된 microVM도 baseline compute는 계속 과금된다. 작업을 suspend해놓고 안 치우는 agent는 느린 누수다. idle connection 관리하듯 suspend된 VM을 추적하고 회수해라.
+- **런칭 시점 리전이 좁다.** N. Virginia, Ohio, Oregon, Tokyo, Ireland. agent가 다른 데서 돌면 아직 옵션이 아니고, 지금 이걸 전제로 설계하면 나중에 마이그레이션이다.
+- **microVM마다 HTTPS URL은 네트워크 모델을 바꾼다.** VM마다 자기 endpoint를 갖는다. 편하긴 한데 ephemeral surface가 확 늘어난다는 뜻이기도 하다. 앞단에 뭘 두고, 로깅하고, 그 URL이 prompt injection이 노릴 수 있는 agent 가시 context로 새 나가지 않게 해라.
+
+## 뭘 해야 하나
+
+코드 생성하는 agent를 돌린다면, 위 네 줄 중 실제로 어디에 있는지 적어둬라. 대부분의 팀은 1번이나 4번이고 microVM 필요 없다. 진짜 필요한 팀, 신뢰 안 되는 코드를 pause/resume 붙여 multi-tenant로 돌리는 팀은, 이제 Firecracker glue 더미 대신 이 일을 위해 만들어진 primitive가 생겼다. 제일 안전해 *보이는* 격리가 아니라, 실제로 필요한 격리를 기준으로 골라라.


### PR DESCRIPTION
## What

Two AWS agent-infrastructure articles, en/ko pairs.

1. **Lambda MicroVMs** (`2026-07-02-where-to-run-agent-generated-code`) - the isolation/speed/state tradeoff for running agent-generated code, with a decision table (Code Interpreter sandbox vs MicroVM vs plain container) and cost/blast-radius pitfalls.
2. **WAF for AgentCore Gateway** (`2026-07-02-waf-for-agentcore-gateway`) - why the MCP gateway is the right perimeter, a rule-by-rule decision tree (rate first, count-mode before block, Bot Control last for A2A), and the "WAF is perimeter not authz" framing.

## Files
- `content/blog/2026-07-02-where-to-run-agent-generated-code.en.md` / `.ko.md`
- `content/blog/2026-07-02-waf-for-agentcore-gateway.en.md` / `.ko.md`

## Checks
- `validate_frontmatter.py`: PASSED, all 200 posts
- em-dash count: 0 across all four files
- no unquoted colon titles
