### PR TITLE
Use DynamoDB managed KMS key

### DIFF
--- a/terraform/modules/draw-api/main.tf
+++ b/terraform/modules/draw-api/main.tf
@@ -65,7 +65,8 @@ resource "aws_dynamodb_table" "documents" {
     type = "S"
   }
   server_side_encryption {
-    enabled = true
+    enabled     = true
+    kms_key_arn = "arn:aws:kms:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:alias/aws/dynamodb"
   }
 }
 


### PR DESCRIPTION
## Summary
- explicitly use the AWS-managed `alias/aws/dynamodb` key for Draw document encryption
- avoid the account default key that points to a deleted KMS key
- keep the AWS provider version unchanged

## Validation
- `tofu -chdir=terraform/env/prod validate`
- `tofu fmt terraform/modules/draw-api/main.tf`

Follow-up to the production failure in run 29132720307.