### PR TITLE
Configure Cognito account recovery

### DIFF
--- a/terraform/modules/draw-api/main.tf
+++ b/terraform/modules/draw-api/main.tf
@@ -25,6 +25,12 @@ resource "aws_cognito_user_pool" "users" {
   admin_create_user_config {
     allow_admin_create_user_only = true
   }
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
   password_policy {
     minimum_length    = 12
     require_lowercase = true


### PR DESCRIPTION
## Summary
- explicitly configure verified-email account recovery for the Draw user pool
- prevent the AWS provider from sending an empty recovery mechanism list during update
- keep the AWS provider version unchanged

## Validation
- `tofu -chdir=terraform/env/prod validate`
- `tofu fmt terraform/modules/draw-api/main.tf`

Follow-up to the production failure in run 29132990289.